### PR TITLE
Updated copyright date.

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -13,7 +13,7 @@ baseurl = "/"
 
 # Enter a copyright notice to display in the site footer.
 # To display a copyright symbol, type `&copy;`.
-copyright = "&copy;2019 KubeEdge"
+copyright = "&copy;2020 KubeEdge"
 
 # Enable analytics by entering your Google Analytics tracking ID
 googleAnalytics = "UA-137983920-1"


### PR DESCRIPTION

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR updates the copyright date from 2019 to 2020


* **What is the current behavior?** (You can also link to an open issue here)
Currently at the bottom in the footer the year is shown as 2019.


* **What is the new behavior (if this is a feature change)?**
The update year will be 2020


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No. there is no breaking change.


* **Other information**:
