### PR TITLE
[Fixes #78] Added the API to fetch latest version from the KubeEdge website.

### DIFF
--- a/functions/latestversion.js
+++ b/functions/latestversion.js
@@ -1,0 +1,13 @@
+exports.handler = function(event, context, callback) {
+    // your server-side functionality
+	const latestVersion = "v1.4";
+	callback(null, {
+    		headers: {
+      			"Access-Control-Allow-Origin": "*",
+      			"Access-Control-Allow-Methods": "GET, HEAD, POST, OPTIONS",
+	      		"Access-Control-Allow-Headers": "*",
+    		},
+    		statusCode: 200,
+    		body: latestVersion,
+  	});
+};

--- a/functions/latestversion.js
+++ b/functions/latestversion.js
@@ -1,5 +1,5 @@
 exports.handler = function(event, context, callback) {
-    // your server-side functionality
+    // Set the latest version here.
 	const latestVersion = "v1.4";
 	callback(null, {
     		headers: {

--- a/functions/latestversion.js
+++ b/functions/latestversion.js
@@ -1,6 +1,6 @@
 exports.handler = function(event, context, callback) {
     // Set the latest version here.
-	const latestVersion = "v1.4";
+	const latestVersion = "v1.3.1";
 	callback(null, {
     		headers: {
       			"Access-Control-Allow-Origin": "*",

--- a/functions/latestversion.js
+++ b/functions/latestversion.js
@@ -4,7 +4,7 @@ exports.handler = function(event, context, callback) {
 	callback(null, {
     		headers: {
       			"Access-Control-Allow-Origin": "*",
-      			"Access-Control-Allow-Methods": "GET, HEAD, POST, OPTIONS",
+      			"Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
 	      		"Access-Control-Allow-Headers": "*",
     		},
     		statusCode: 200,

--- a/functions/latestversion.js
+++ b/functions/latestversion.js
@@ -1,13 +1,13 @@
 exports.handler = function(event, context, callback) {
     // Set the latest version here.
-	const latestVersion = "v1.3.1";
-	callback(null, {
-    		headers: {
-      			"Access-Control-Allow-Origin": "*",
-      			"Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
-	      		"Access-Control-Allow-Headers": "*",
-    		},
-    		statusCode: 200,
-    		body: latestVersion,
-  	});
+    const latestVersion = "v1.3.1";
+    callback(null, {
+        headers: {
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
+            "Access-Control-Allow-Headers": "*",
+        },
+        statusCode: 200,
+        body: latestVersion,
+    });
 };

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,7 @@
 [build]
 publish = "public"
 command = "hugo"
+functions = "functions/"
 
 [context.production.environment]
   HUGO_VERSION = "0.53"


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [*] The commit message follows our guidelines
- [*] Tests for the changes have been added (for bug fixes / features)
- [*] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR fixes #78 . Added an API to return the latest version of KubeEdge from the website.


* **What is the current behavior?** (You can also link to an open issue here)
Currently there is no functionality to get the latest version of KubeEdge.


* **What is the new behavior (if this is a feature change)?**
if the user wishes to fetch the latest version of KubeEdge they can use CURL or enter the URL in the browser and get the latest version.
This is implemented using Netlify Functions that deploys a serverless lambda function on the fly.
More information can be found [here](https://docs.netlify.com/functions/overview/#manage-your-serverless-functions).


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

* **Other information**:
