### PR TITLE
Added redirect in the URL to rewrite the path of latestversion API

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -29,3 +29,9 @@ HUGO_VERSION = "0.53"
 
 [context.next.environment]
 HUGO_ENABLEGITINFO = "true"
+
+[[redirects]]
+  from = "/latestversion"
+  to = "/.netlify/functions/latestversion"
+  status = 200
+  force = true # COMMENT: ensure that we always redirect


### PR DESCRIPTION

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
The API path for the latest version API is `/.netlify/functions/latestversion` To make it easier the URL is rewritten to redirect from `/latestversion`


* **What is the current behavior?** (You can also link to an open issue here)
The API has to be invoked using `/.netlify/functions/latestversion`


* **What is the new behavior (if this is a feature change)?**
API can be invoked using `/latestversion`


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


* **Other information**:
