### PR TITLE
hide Versions nav

### DIFF
--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -96,6 +96,20 @@
           <a class="nav-link js-search" href="#"><i class="fas fa-search" aria-hidden="true"></i></a>
         </li>
         {{ end }}
+<!--        {{ if  .Site.Params.versions }}-->
+<!--          <li class="nav-item dropdown">-->
+<!--            <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">-->
+<!--              <span>{{ .Site.Params.version_menu }}</span>-->
+<!--            </a>-->
+<!--            <ul class="dropdown-menu">-->
+<!--              {{ range .Site.Params.versions }}-->
+<!--                <li class="dropdown-item my-0 py-0 mx-0 px-0">-->
+<!--                  <a class="dropdown-item" href="{{ .url }}">{{ .version }}</a>-->
+<!--                </li>-->
+<!--              {{ end }}-->
+<!--            </ul>-->
+<!--          </li>-->
+<!--        {{ end }}-->
 
         {{ if .IsTranslated }}
         <li class="nav-item dropdown">
@@ -113,20 +127,6 @@
             {{ end }}
           </ul>
         </li>
-        {{ end }}
-        {{ if  .Site.Params.versions }}
-          <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-              <span>{{ .Site.Params.version_menu }}</span>
-            </a>
-            <ul class="dropdown-menu">
-              {{ range .Site.Params.versions }}
-                <li class="dropdown-item my-0 py-0 mx-0 px-0">
-                  <a class="dropdown-item" href="{{ .url }}">{{ .version }}</a>
-                </li>
-              {{ end }}
-            </ul>
-          </li>
         {{ end }}
         {{ if .Site.Params.day_night }}
         <li class="nav-item">


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
extend ```add version nav #77```, hide versions nav in ```master``` ,and change its postion,```versions``` would be on the left of ```English``` if you uncomment。
origin:![image](https://user-images.githubusercontent.com/48508048/92627494-0653ed80-f2fe-11ea-9206-50b62d5b81ca.png)

* **Does this PR introduce a breaking change?
No, it just comment ```versions``` related in  navbar.html and change its position .

* **Other information:
demo: just like origin website two months ago
/assign @kevin-wangzefeng
And I  would make pr to add versions nav in ```website-v2 ``` later.

