### PR TITLE
add Versions navbar

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -60,3 +60,20 @@ preserveTaxonomyNames = true
   category = "categories"
   publication_type = "publication_types"
   author = "authors"
+
+[params]
+# Menu title if your navbar has a versions selector to access old versions of your site.
+# This menu appears only if you have at least one [params.versions] set.
+version_menu = "Versions"
+
+[[params.versions]]
+fullversion = "master"
+version = "master"
+githubbranch = "master"
+url = "https://kubeedge.io/en/"
+
+[[params.versions]]
+fullversion = "website-v2"
+version = "website-v2"
+githubbranch = "website-v2"
+url = "https://website-v2.kubeedge.io/en/"

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,0 +1,141 @@
+<nav class="navbar navbar-light fixed-top navbar-expand-lg py-0" id="navbar-main">
+  <div class="container">
+
+    <!-- Brand and toggle get grouped for better mobile display -->
+      <a class="navbar-brand" href="{{ "/" | relLangURL }}">
+        {{- if .Site.Params.logo -}}
+        <img src="{{ printf "/img/%s" .Site.Params.logo | relURL }}" alt="{{ .Site.Title }}">
+        {{- else -}}
+        {{- .Site.Title -}}
+        {{- end -}}
+      </a>
+      {{ if or .Site.Menus.main .IsTranslated }}
+      <button type="button" class="navbar-toggler" data-toggle="collapse"
+              data-target="#navbar" aria-controls="navbar" aria-expanded="false" aria-label="{{ i18n "toggle_navigation" }}">
+        <span><i class="fas fa-bars"></i></span>
+      </button>
+      {{ end }}
+
+    <!-- Collect the nav links, forms, and other content for toggling -->
+    <div class="collapse navbar-collapse" id="navbar">
+
+      <!-- Left Nav Bar -->
+      {{ $align_right := .Site.Params.menu_align_right | default true }}
+      <ul class="navbar-nav {{ if $align_right }}ml-auto{{ else }}mr-auto{{ end }}">
+        {{ range .Site.Menus.main }}
+
+        {{ if .HasChildren }}
+        <li class="nav-item dropdown">
+          <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" aria-haspopup="true">
+            {{ .Pre }}
+            <span>{{ .Name | safeHTML }}</span>
+            {{ .Post }}
+            <span class="caret"></span>
+          </a>
+          <ul class="dropdown-menu">
+            {{ range .Children }}
+            <li class="dropdown-item my-0 py-0 mx-0 px-0">
+              <a href="{{ .URL | relLangURL }}"{{ if $.IsHome }} data-target="{{ .URL }}"{{ end }}>
+                {{ .Pre }}
+                <span>{{ .Name | safeHTML }}</span>
+                {{ .Post }}
+              </a>
+            </li>
+            {{ end }}
+          </ul>
+        </li>
+
+        {{ else }}
+
+        {{/* Set target for link. */}}
+        {{ $.Scratch.Set "target" "" }}
+        {{ if gt (len .URL) 4 }}
+          {{ if eq "http" (slicestr .URL 0 4) }}
+            {{ $.Scratch.Set "target" " target=\"_blank\" rel=\"noopener\"" }}
+          {{ end }}
+        {{ end }}
+
+        <li class="nav-item">
+          <a class="nav-link" href="{{ .URL | relLangURL }}"{{ if $.IsHome }} data-target="{{ .URL }}"{{ end }}{{ ($.Scratch.Get "target") | safeHTMLAttr }}>
+            {{ .Pre }}
+            <span>{{ .Name | safeHTML }}</span>
+            {{ .Post }}
+          </a>
+        </li>
+
+        {{ end }}
+        {{ end }}
+
+      {{ if not $align_right | and (.IsTranslated | or .Site.Menus.main_right | or .Site.Params.search.engine | or .Site.Params.day_night) }}
+      </ul>
+      <ul class="navbar-nav ml-auto">
+      {{ end }}
+
+        {{ range .Site.Menus.main_right }}
+
+        {{/* Set target for link. */}}
+        {{ $.Scratch.Set "target" "" }}
+        {{ if gt (len .URL) 4 }}
+        {{ if eq "http" (slicestr .URL 0 4) }}
+        {{ $.Scratch.Set "target" " target=\"_blank\" rel=\"noopener\"" }}
+        {{ end }}
+        {{ end }}
+
+        <li class="nav-item">
+          <a class="nav-link" href="{{ .URL | relLangURL }}"{{ if $.IsHome }} data-target="{{ .URL }}"{{ end }}{{ ($.Scratch.Get "target") | safeHTMLAttr }}>
+          {{ .Pre }}
+          <span>{{ .Name | safeHTML }}</span>
+          {{ .Post }}
+          </a>
+        </li>
+
+        {{ end }}
+
+        {{ if .Site.Params.search.engine }}
+        <li class="nav-item">
+          <a class="nav-link js-search" href="#"><i class="fas fa-search" aria-hidden="true"></i></a>
+        </li>
+        {{ end }}
+        {{ if  .Site.Params.versions }}
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              <span>{{ .Site.Params.version_menu }}</span>
+            </a>
+            <ul class="dropdown-menu">
+              {{ range .Site.Params.versions }}
+                <li class="dropdown-item my-0 py-0 mx-0 px-0">
+                  <a class="dropdown-item" href="{{ .url }}">{{ .version }}</a>
+                </li>
+              {{ end }}
+            </ul>
+          </li>
+        {{ end }}
+        {{ if .IsTranslated }}
+        <li class="nav-item dropdown">
+          <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" aria-haspopup="true">
+            <i class="fas fa-globe" aria-hidden="true"></i>
+            <span>{{ index .Site.Data.i18n.languages .Lang }}</span>
+          </a>
+          <ul class="dropdown-menu">
+            {{ range .Translations }}
+            <li class="dropdown-item my-0 py-0 mx-0 px-0">
+              <a href="{{ .Permalink }}"{{ if $.IsHome }} data-target="{{ .URL }}"{{ end }}>
+                <span>{{ index .Site.Data.i18n.languages .Lang }}</span>
+              </a>
+            </li>
+            {{ end }}
+          </ul>
+        </li>
+        {{ end }}
+        
+        {{ if .Site.Params.day_night }}
+        <li class="nav-item">
+          <a class="nav-link js-dark-toggle" href="#"><i class="fas fa-moon" aria-hidden="true"></i></a>
+        </li>
+        {{ end }}
+
+      </ul>
+
+    </div><!-- /.navbar-collapse -->
+  </div><!-- /.container -->
+</nav>


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (update)
extend ```add version nav #77```,the same as it but to ```website-v2``` rather than ```master```
like:
![image](https://user-images.githubusercontent.com/48508048/92629032-45833e00-f300-11ea-971f-f6216ac1b3c0.png)

* **Does this PR introduce a breaking change?
No, it just add navbar.html and add some settings in config.toml , you can delete it to restore anytime.

* **Other information:
demo: https://testke.netlify.app/en/ 
but:
![image](https://user-images.githubusercontent.com/48508048/92629032-45833e00-f300-11ea-971f-f6216ac1b3c0.png)
/assign @kevin-wangzefeng
master for: https://kubeedge.io/en/ and website-v2 for: https://website-v2.kubeedge.io/en/