### PR TITLE
Add CNCF logo and trademark language to footer

### DIFF
--- a/layouts/partials/footer_section.html
+++ b/layouts/partials/footer_section.html
@@ -1,22 +1,35 @@
+{{ $year     := now.Year }}
+
+<style>
+.is-cncf-logo {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+  width: 50%;
+  padding: 30px;
+}
+</style>
+
 <footer class="site-footer">
-  {{ with .Site.GetPage "privacy.md" }}
-  <p class="powered-by">
-    {{ printf "<a href=\"%s\">%s</a>" .RelPermalink .Title | safeHTML }}
-  </p>
-  {{ end }}
+  <div>
+    <p style="font-size:larger;">
+      KubeEdge is a <a href="https://cncf.io/">Cloud Native Computing Foundation</a> incubating project.
+    </p>
+    <img class="is-cncf-logo" src="https://raw.githubusercontent.com/cncf/artwork/master/other/cncf/horizontal/color/cncf-color.png">
+    <p>The Linux Foundation has registered trademarks and
+      uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a
+        href="https://www.linuxfoundation.org/trademark-usage" target="_blank">Trademark Usage</a> page.
+    </p>
+    <p class="has-text-centered">
+      {{ $year}} &copy; KubeEdge Project Authors. All rights reserved.
+    </p>
+  </div>
 
-  <p class="powered-by">
-    {{ with .Site.Copyright }}{{ . | markdownify}} &middot; {{ end }}
-
-    
-    {{ if ne .Type "docs" }}
-    <span class="float-right" aria-hidden="true">
-      <a href="#" id="back_to_top">
-        <span class="button_icon">
-          <i class="fas fa-chevron-up fa-2x"></i>
-        </span>
-      </a>
-    </span>
-    {{ end }}
-  </p>
+  <span class="float-right" aria-hidden="true">
+    <a href="#" id="back_to_top">
+      <span class="button_icon">
+        <i class="fas fa-chevron-up fa-2x"></i>
+      </span>
+    </a>
+  </span>
 </footer>


### PR DESCRIPTION
fixes #87

Congratulations on your incubation status! 🎉 

## Description

This PR adds some lightweight CSS, adapted from the [Falco website](https://github.com/falcosecurity/falco-website):
- Adds the CNCF logo and incubation statement
- Adds a CNCF/LF trademark statement to the footer

## Deploy preview

https://deploy-preview-88--competent-hypatia-4195b7.netlify.app/en/

## Notes

It looks like the site used a Hugo theme in the past and contains some leftover CSS. I cleaned up what I could while avoiding anything that can't be easily removed or adapted if you add a new theme later.