### PR TITLE
Return Hugo code to the footer

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -13,7 +13,7 @@ baseurl = "/"
 
 # Enter a copyright notice to display in the site footer.
 # To display a copyright symbol, type `&copy;`.
-copyright = "&copy;2020 KubeEdge"
+copyright = "2020 &copy; KubeEdge Project Authors. All rights reserved."
 
 # Enable analytics by entering your Google Analytics tracking ID
 googleAnalytics = "UA-137983920-1"

--- a/layouts/partials/footer_section.html
+++ b/layouts/partials/footer_section.html
@@ -1,29 +1,35 @@
-{{ $year     := now.Year }}
-
 <style>
-.is-cncf-logo {
-  display: block;
-  margin-left: auto;
-  margin-right: auto;
-  width: 50%;
-  padding: 30px;
-}
+  .is-cncf-logo {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    width: 50%;
+    padding: 30px;
+  }
 </style>
 
 <footer class="site-footer">
+  {{ with .Site.GetPage "privacy.md" }}
+  <p class="powered-by">
+    {{ printf "<a href=\"%s\">%s</a>" .RelPermalink .Title | safeHTML }}
+  </p>
+  {{ end }}
+
   <div>
-    <p style="font-size:larger;">
+    <p style="font-size: large;">
       KubeEdge is a <a href="https://cncf.io/">Cloud Native Computing Foundation</a> incubating project.
     </p>
     <img class="is-cncf-logo" src="https://raw.githubusercontent.com/cncf/artwork/master/other/cncf/horizontal/color/cncf-color.png">
-    <p>The Linux Foundation has registered trademarks and
-      uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a
-        href="https://www.linuxfoundation.org/trademark-usage" target="_blank">Trademark Usage</a> page.
-    </p>
-    <p class="has-text-centered">
-      {{ $year}} &copy; KubeEdge Project Authors. All rights reserved.
+    <p>
+      The Linux Foundation has registered trademarks and uses trademarks. 
+      For a list of trademarks of The Linux Foundation, please see our 
+      <a href="https://www.linuxfoundation.org/trademark-usage" target="_blank">
+        Trademark Usage</a> page.
     </p>
   </div>
+
+  <p class="powered-by">
+    {{ with .Site.Copyright }}{{ . | markdownify}} &middot; {{ end }}
 
   <span class="float-right" aria-hidden="true">
     <a href="#" id="back_to_top">


### PR DESCRIPTION
## Description

Per https://github.com/kubeedge/website/pull/88#discussion_r486773495, this PR restores Hugo code to the footer removed in #88 and shifts the copyright statement into `config.toml` to conform to the site's previous Hugo configuration.

## Preview URL

https://deploy-preview-89--kubeedge.netlify.app/en/