### PR TITLE
Updated the copyright year to 2021

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -13,7 +13,7 @@ baseurl = "/"
 
 # Enter a copyright notice to display in the site footer.
 # To display a copyright symbol, type `&copy;`.
-copyright = "2020 &copy; KubeEdge Project Authors. All rights reserved."
+copyright = "2021 &copy; KubeEdge Project Authors. All rights reserved."
 
 # Enable analytics by entering your Google Analytics tracking ID
 googleAnalytics = "UA-137983920-1"


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [*] The commit message follows our guidelines
- [*] Tests for the changes have been added (for bug fixes / features)
- [*] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR updates the copyright year in the website footer.


* **What is the current behavior?** (You can also link to an open issue here)
The current copyright year is displayed as 2020.


* **What is the new behavior (if this is a feature change)?**
The copyright year is updated to 2021


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
N0.


* **Other information**:
The change can be viewed in the display preview.