### PR TITLE
fix:broken link

### DIFF
--- a/content/en/docs/developer/troubleshooting.md
+++ b/content/en/docs/developer/troubleshooting.md
@@ -74,4 +74,4 @@ Connect to the edge node and then either
 - use the log file located in `/var/log/pods` or
 - use commands like `docker logs <container id>`
 
-You can also enable `kubectl logs` feature refer to this [guide](../keadm#enable-kubectl-logs-feature).
+You can also enable `kubectl logs` feature refer to this [guide](../../setup/keadm/#enable-kubectl-logs-feature).


### PR DESCRIPTION
Signed-off-by: Nilisha Jaiswal <jaiswal.nilisha05@gmail.com>

* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix


* **What is the current behavior?** (You can also link to an open issue here)
![Screenshot (33)](https://user-images.githubusercontent.com/73216246/162053127-057ec7f9-6eba-4da3-a780-77f888e19535.png)
The link to [guide](https://kubeedge.io/en/docs/developer/keadm#enable-kubectl-logs-feature) in the [troubleshooting](https://kubeedge.io/en/docs/developer/troubleshooting/) page is broken


* **What is the new behavior (if this is a feature change)?**
This pr fixes the issue by leading the link to [guide](https://kubeedge.io/en/docs/setup/keadm/#enable-kubectl-logs-feature)

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
