### PR TITLE
add redirect rule to edgemesh site

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -35,3 +35,10 @@ HUGO_ENABLEGITINFO = "true"
   to = "/.netlify/functions/latestversion"
   status = 200
   force = true # COMMENT: ensure that we always redirect
+
+[[redirects]]
+  from = "https://edgemesh.kubeedge.io"
+  to = "https://edgemesh.netlify.app"
+  status = 200
+  force = true
+


### PR DESCRIPTION
Signed-off-by: Kevin Wang <kevinwzf0126@gmail.com>

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Add redirect rule for edgemesh site.

Currently we have edgemesh site deployed at https://edgemesh.netlify.app
However setting CNAME record on netlify from edgemesh.kubeedge.io to edgemesh.netlify.app doesn't work.
This PR is trying to enable proxy redirect function for shadowing edgemesh.netlify.app with edgemesh.kubeedge.io.

* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
Unfortunately we are not able to debug without merging this change. Follow up changes may be needed, if this doesn't work.