### PR TITLE
fix: doc style

### DIFF
--- a/content/en/docs/developer/device_crd.md
+++ b/content/en/docs/developer/device_crd.md
@@ -220,6 +220,7 @@ The following are the steps to
 
 5. The reported values of the device twin are updated by the mapper application at the edge and this data is synced back to the cloud by the device controller. User can view the update at the cloud by checking his device instance object.
 
-```shell
-    Note: Sample device model and device instance for a few protocols can be found at $GOPATH/src/github.com/kubeedge/kubeedge/build/crd-samples/devices
+Note: Sample device model and device instance for a few protocols can be found at 
+```shell 
+$GOPATH/src/github.com/kubeedge/kubeedge/build/crd-samples/devices
 ```


### PR DESCRIPTION
Signed-off-by: Nilisha Jaiswal <jaiswal.nilisha05@gmail.com>

* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
In the [device manager page](https://kubeedge.io/en/docs/developer/device_crd/) the note section is inside the codeblock which is against the documentation style. This pull request fixes this.


* **What is the current behavior?** (You can also link to an open issue here)
![Screenshot (53)](https://user-images.githubusercontent.com/73216246/171084343-42cdf599-4b2d-4886-86e4-eeb1f5ba5b87.png)



* **What is the new behavior (if this is a feature change)?**
![Screenshot (54)](https://user-images.githubusercontent.com/73216246/171084303-c679a019-2215-45cc-a958-251ab9a2d199.png)



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
