### PR TITLE
add hugo version considerations in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ brew install hugo
 
 #### Debian:
 
-1. Download the latest Debian package from the [Hugo website][hugo-install].
-  For example, `hugo_0.54_Linux-64bit.deb`.
+1. Download the Debian package from the [Hugo website][hugo-install].
+   Make sure to install the Hugo version specified by the `HUGO_VERSION` environment variable in the [`netlify.toml`](netlify.toml#L7) file.
+  For example, [hugo_0.54_Linux-64bit.deb][hugo_0.54_Linux-64bit.deb].
 1. Install the package using `dpkg`:
 
     ```
@@ -119,3 +120,4 @@ Going forward, the versioned sites should follow this convention:
 
 [kubeedge-contributor-guide]: CONTRIBUTING.md
 [kubeEdge-website-repo]: https://github.com/kubeedge/website
+[hugo_0.54_Linux-64bit.deb]: https://github.com/gohugoio/hugo/releases/download/v0.54.0/hugo_0.54.0_Linux-64bit.deb

--- a/README_zh.md
+++ b/README_zh.md
@@ -37,7 +37,9 @@ brew install hugo
 
 #### Debian:
 
-1. 从 [Hugo网站][hugo-install].下载最新的Debian软件包。例如，`hugo_0.54_Linux-64bit.deb` 。
+1. 从 [Hugo网站][hugo-install].下载Debian软件包。
+   确保安装由 [`netlify.toml`](netlify.toml#L7) 文件中的 `HUGO_VERSION` 环境变量指定的 Hugo 版本。
+   例如，[hugo_0.54_Linux-64bit.deb][hugo_0.54_Linux-64bit.deb]。
 1. 使用 `dpkg` 命令安装软件包：
 
     ```
@@ -95,3 +97,4 @@ Hugo 参考文档：
 
 [kubeedge-contributor-guide]: CONTRIBUTING.md
 [kubeEdge-website-repo]: https://github.com/kubeedge/website
+[hugo_0.54_Linux-64bit.deb]: https://github.com/gohugoio/hugo/releases/download/v0.54.0/hugo_0.54.0_Linux-64bit.deb


### PR DESCRIPTION
Signed-off-by: Xieql <xieqianglong@huawei.com>

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
docs update
I couldn't start the website with the latest version of hugo, but it returned to normal after using the same version of hugo as the configuration. And there is also a reminder of this hugo version on the k8s document that also uses hugo https://github.com/kubernetes/website
It has been verified on Windows system and Debian system: it is necessary to keep the hugo version consistent
I guess it is because the current version 0.104.1 is too different from the previous version 0.54.0.

* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
