### PR TITLE
Added padding in "recent new" section 

### DIFF
--- a/src/components/blogPost/index.scss
+++ b/src/components/blogPost/index.scss
@@ -6,6 +6,7 @@
           .left {
             flex: 0 0 100%;
             max-width: 100%;
+            
           }
         }
       }
@@ -28,7 +29,7 @@
     -ms-flex-wrap: wrap;
     flex-wrap: wrap;
     margin-right: -15px;
-    margin-left: -15px;
+    margin-left: 15px;
 
     .left {
       flex: 0 0 33.333333%;


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


In mobile view the padding was not added to the blog post container section.

Previous view -
![image](https://github.com/kubeedge/website/assets/97254881/42b163ae-f9c5-44d1-9cea-008bcad73a05)

Updated view - 
![image](https://github.com/kubeedge/website/assets/97254881/5e26a172-6347-46be-ab5f-86f39307fb98)

This is a change in styling.








