### PR TITLE
responsiveness of the Why KubeEdge section

### DIFF
--- a/src/components/why/styles.module.css
+++ b/src/components/why/styles.module.css
@@ -1,3 +1,4 @@
+/* Default styles */
 .whyContainer {
   display: flex;
   flex-direction: column;
@@ -18,4 +19,17 @@
 .reasonContent {
   font-size: 0.9rem;
   white-space: pre-wrap;
+}
+
+/* Responsive styles */
+@media screen and (max-width: 768px) {
+  .reasonBox {
+    flex-basis: 50%; /* Show two reasons per row on screens up to 768px */
+  }
+}
+
+@media screen and (max-width: 480px) {
+  .reasonBox {
+    flex-basis: 100%; /* Show one reason per row on screens up to 480px */
+  }
 }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ x] The commit message follows our guidelines
- [x ] Tests for the changes have been added (for bug fixes / features)
- [ x] Docs have been added / updated (for bug fixes / features)

made "Why KubeEdge section" responsive, initially it was not responsive
issue #385 

before
![localhost_3000_(iPhone 12 Pro) (1)](https://github.com/kubeedge/website/assets/116518876/ae613ac2-8367-4193-b459-ca6533acc572)

after
![localhost_3000_(iPhone 12 Pro)](https://github.com/kubeedge/website/assets/116518876/710448df-f807-408b-844b-c2a2a2a633e1)
