### PR TITLE
Update kubeedge slack invitation link to cncf

### DIFF
--- a/docs/community/slack.md
+++ b/docs/community/slack.md
@@ -1,0 +1,23 @@
+---
+title: How to Join KubeEdge Slack 
+sidebar_position: 7
+---
+
+# Slack
+
+
+If you have any questions you are always welcome in KubeEdge channels on the CNCF Slack:
+
+- Navigate to https://slack.cncf.io/ and create your Slack account.
+- Find us in one of the following channels and ask your question:
+    - [#kubeedge](https://cloud-native.slack.com/archives/C066UJZJKQE)
+    - [#kubeedge-announcement](https://cloud-native.slack.com/archives/C067DTAF4Q1)
+    - [#kubeedge-dev](https://cloud-native.slack.com/archives/C06718TB6F4)
+    - [#kubeedge-dashboard](https://cloud-native.slack.com/archives/C066LNA3015)
+    - [#kubeedge-docs](https://cloud-native.slack.com/archives/C06718RDHCJ)
+    - [#kubeedge-sig-ai](https://cloud-native.slack.com/archives/C067DTGJJM7)
+    - [#kubeedge-sig-device-iot](https://cloud-native.slack.com/archives/C067Q8J3KTJ)
+    - [#kubeedge-sig-robotics](https://cloud-native.slack.com/archives/C066LNMUME3)
+    - [#kubeedge-sig-security](https://cloud-native.slack.com/archives/C067Q8LC3T2)
+    - [#kubeedge-sig-mec](https://cloud-native.slack.com/archives/C06716458P5)
+

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -184,7 +184,7 @@ const config = {
             className: "header-twitter-link heade-icon",
           },
           {
-            href: "https://kubeedge.slack.com/join/shared_invite/enQtNjc0MTg2NTg2MTk0LWJmOTBmOGRkZWNhMTVkNGU1ZjkwNDY4MTY4YTAwNDAyMjRkMjdlMjIzYmMxODY1NGZjYzc4MWM5YmIxZjU1ZDI#/shared-invite/email",
+            to: "/docs/community/slack",
             position: "right",
             className: "header-slack-link heade-icon",
           },


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Slack channels of KubeEdge will be migrated to CNCF as described in https://github.com/kubeedge/community/issues/181, update the invitation link in this PR.
