### PR TITLE
Fix incorrect path of edgecore configuration

### DIFF
--- a/docs/advanced/debug.md
+++ b/docs/advanced/debug.md
@@ -83,7 +83,7 @@ sidebar_position: 3
 
 2. Update `edgecore` configuration to enable **edgeStream**.
 
-    This modification needs to be done all edge system where `edgecore` runs to update `/etc/kubeedge/config/cloudcore.yaml`.
+    This modification needs to be done all edge system where `edgecore` runs to update `/etc/kubeedge/config/edgecore.yaml`.
     Make sure the `server` IP address to the cloudcore IP (the same as $CLOUDCOREIPS).
 
     ```yaml


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
      docs update

* **What is the current behavior?** (You can also link to an open issue here)
The configuration path of edgecore is wrong in Advanced Configuration:      
![wrong_path](https://github.com/user-attachments/assets/2dd14340-bb71-460e-b85c-d0cf74e68d5c)

* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
