### PR TITLE
Fix typo in keadm installation command

### DIFF
--- a/docs/setup/install-with-keadm.md
+++ b/docs/setup/install-with-keadm.md
@@ -22,7 +22,7 @@ There're three ways to download the `keadm` binary:
     ```shell
     wget https://github.com/kubeedge/kubeedge/releases/download/v1.17.0/keadm-v1.17.0-linux-amd64.tar.gz
     tar -zxvf keadm-v1.17.0-linux-amd64.tar.gz
-    cp keadm-1.17.0-linux-amd64/keadm/keadm /usr/local/bin/keadm
+    cp keadm-v1.17.0-linux-amd64/keadm/keadm /usr/local/bin/keadm
     ```
 
 2. Download from the official KubeEdge release image on Docker Hub.


### PR DESCRIPTION
Corrected the path in the setup instructions from "keadm-1.17.0-linux-amd64" to "keadm-v1.17.0-linux-amd64". This ensures users can successfully copy the keadm binary to the correct directory.

* **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
