### PR TITLE
keadm reset does not have `--kube-config` flag anymore.

### DIFF
--- a/docs/setup/install-with-keadm.md
+++ b/docs/setup/install-with-keadm.md
@@ -541,7 +541,7 @@ It provides a flag for users to specify kubeconfig path, the default path is `/r
  Example:
 
 ```shell
- # keadm reset --kube-config=$HOME/.kube/config
+ # keadm reset
  # or
  # keadm deprecated reset
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs/current/setup/install-with-keadm.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/setup/install-with-keadm.md
@@ -450,7 +450,7 @@ KubeEdge edgecore is running, For logs visit:  /var/log/kubeedge/edgecore.log
 例子：
 
 ```shell
- # keadm reset --kube-config=$HOME/.kube/config
+ # keadm reset
 ```
 
 ### 节点


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Which issue(s) this PR fixes**:

N.A

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

- `keadm reset --kube-config=$HOME/.kube/config` does not work as shown in the documentation.

* **What is the current behavior?** (You can also link to an open issue here)

```bash
root@tomoyafujita:~# keadm reset --kube-config=$HOME/.kube/config
Error: unknown flag: --kube-config
Usage:
  keadm reset [flags]

Examples:

For cloud node:
keadm reset

For edge node:
keadm reset


Flags:
      --cloudcore-ipport string          Use this key to set kube-config path, eg: $HOME/.kube/config (default "/root/.kube/config")
      --force                            Reset the node without prompting for confirmation
  -h, --help                             help for reset
      --remote-runtime-endpoint string   Use this key to set container runtime endpoint

execute keadm command failed:  unknown flag: --kube-config
```

* **What is the new behavior (if this is a feature change)?**

- should be `keadm reset`.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:

N.A