### PR TITLE
Add FAQ for certificate issues when deploying on k3s

### DIFF
--- a/docs/faq/setup.md
+++ b/docs/faq/setup.md
@@ -315,7 +315,7 @@ Solution: Add the following parameter when starting k3s:
 
 This disables kubelet certificate verification, which resolves the certificate validation failure.
 
-### 在 k3s 上部署时的证书验证问题
+
 
 ## Advertise-address related issues
 The most common problems is due to that the IP address that cloudcore expose, is NOT the same as the IP address that edgecore use to connect to.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/faq/setup.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/faq/setup.md
@@ -483,3 +483,20 @@ modules:
 :::tip
 当你需要使用`systemd` cgroup驱动，并且在使用keadm join安装部分版本(v1.12.0-1.12.4, v1.13.0-1.13.2, v1.14.0-1.14.2)的EdgeCore时，可能也会出现`OCI runtime create failed`的报错，建议使用对应release版本的最新patch版本
 :::
+
+## 在 k3s 上部署时的证书验证问题
+
+当在启用了边缘日志功能的 k3s 上部署 KubeEdge 时，你可能会遇到以下错误:
+
+```
+Error from server: Get "https://192.168.50.132:10351/containerLogs/default/nginx/nginx?follow=true": tls: failed to verify certificate: x509: cannot validate certificate for 192.168.50.132 because it doesn't contain any IP SANs
+```
+
+解决方案：在启动 k3s 时添加以下参数:
+
+```bash
+--kube-apiserver-arg=kubelet-certificate-authority=
+```
+
+这将禁用 kubelet 证书验证，从而解决证书验证失败的问题。
+


### PR DESCRIPTION
Documented a solution for TLS certificate verification errors encountered on k3s deployments with edge logging enabled. This includes a specific parameter to disable kubelet certificate verification, resolving the validation failure. Added both English and Chinese explanations for global accessibility.

* **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
