### PR TITLE
Fix: Translate case study Markdown files to English

### DIFF
--- a/src/pages/case-studies/CAII/index.mdx
+++ b/src/pages/case-studies/CAII/index.mdx
@@ -7,6 +7,115 @@ tags:
   - UserCase
 ---
 
-# The architecture design and application of KubeEdge in Big Data Center of China Academy Industrial Internet
+# Architecture Design and Application of KubeEdge in the National Industrial Internet Big Data Center
 
-For more detailed information, please visit http://kubeedge.io/zh/case-studies/CAII.
+## Issues and Challenges
+
+### Requirements
+
+- Collect production and operational data from factories and aggregate them in the cloud.
+- Unified cloud control: determine what data to collect and how to process it.
+
+![Background](/img/casestudies/CAII/background.png)
+
+### Challenges
+
+- Only the edge can actively connect to the cloud; the cloud cannot actively connect to the edge (the edge has no public IP).
+- Must be flexible enough to adapt to various industrial devices and protocols.
+- Requires edge autonomy, ensuring edge functionality even when the network is unstable.
+- Supports edge computing capabilities to run various applications on edge nodes.
+- Low resource consumption and power efficiency.
+
+## Technology Selection
+
+KubeEdge provides cloud-edge collaboration, lightweight resource consumption, and device management capabilities, making it a perfect fit for our needs.
+
+### Architecture Design
+
+![Architecture Design](/img/casestudies/CAII/arch.png)
+
+## Overall Framework
+
+In the National Industrial Internet Big Data Center, KubeEdge plays a core role in device and application management. A Kubernetes (K8s) cluster is deployed in the cloud with KubeEdge’s **CloudCore**, where all management and operational data is stored. On the edge, industrial computers or gateways run **EdgeCore**, responsible for containerized applications, including device management and data collection.
+
+Below **EdgeCore**, the **Mapper** module, defined by the KubeEdge community, handles device management and data collection. The community currently provides Modbus and Bluetooth support. To manage a camera or other devices, developers must write Mappers according to community standards.
+
+Above this, we have encapsulated a management service layer using **Java and Spring Cloud**. This extra abstraction prevents exposing KubeEdge or K8s APIs directly, improving security and ensuring better data isolation.
+
+Finally, we created an **Industrial APP Marketplace**, allowing developers to publish **Mappers** for commercial or free distribution, fostering an ecosystem around KubeEdge.
+
+## Data Collection
+
+### Enhancements to KubeEdge
+
+1. **Support for a Wider Range of Industrial Devices and Protocols**
+
+   - Initially, KubeEdge only supported Bluetooth and Modbus, making protocol extensions difficult. To address this, we introduced:
+     - `CustomizedValue` field for extending existing protocols.
+     - `CustomizedProtocol` field for defining entirely custom protocols.
+
+2. **More Flexible Device Data Collection Configurations**
+
+   - Traditional IT follows a **template-first, instance-second** approach, whereas industrial setups often define instances first and copy them for modification.
+   - We moved `PropertyVisitor` from the **Device model** to **DeviceInstance** and introduced dynamic collection cycles based on measurement requirements.
+   - **Example:** Temperature sensors might require hourly data collection, while energy consumption metrics may need different frequencies.
+
+3. **Optimized Twin Property Dispatching**
+4. **Added Bypass Data Configuration**
+
+## Bypass Data Processing
+
+![Bypass Data Processing](/img/casestudies/CAII/data-process.png)
+
+- Allows **Mapper** to push time-series data to the **edge MQTT broker** without processing by EdgeCore.
+- Integrated with **EMQX Kuiper**, enabling metadata retrieval from **DeviceProfile**.
+- KubeEdge sends data cleansing rules to **Kuiper**.
+- Third-party applications can retrieve data directly from **edge MQTT**.
+
+## Status Monitoring
+
+Effective status monitoring is crucial for commercialization. The KubeEdge community provides **Cloud Stream**, which works with **MetricServer** and **Prometheus** but requires **iptables-based traffic interception**, leading to inefficiencies.
+
+### Our Solution:
+
+- A **scheduled task container** runs on edge nodes, collecting local metrics via **NodeExporter**.
+- Data is pushed to **PushGateway**, an official Prometheus component, allowing centralized monitoring.
+
+## Case Studies
+
+### Case 1: OPC-UA Data Collection and Processing
+
+Through our **Industrial APP Marketplace**, users can deploy an **OPC-UA Mapper** to edge gateways. Configuration is performed via a web interface, enabling data collection from industrial devices:
+
+- **OPC-UA Mapper** collects temperature data.
+- **Edge node alarm application** retrieves data directly.
+- If data exceeds a threshold, an **alarm triggers and stops the device**.
+- **KubeEdge dynamically adjusts thresholds**.
+
+### Case 2: Industrial Video Surveillance
+
+This edge-autonomous application performs **AI inference locally**. If required, cloud-trained models are deployed to the edge via KubeEdge. Key features include:
+
+- **KubeEdge manages video surveillance applications on edge nodes.**
+- **Edge video security applications run autonomously.**
+- **Cameras capture live streams for AI analysis.**
+- **Detects safety helmets and protective clothing compliance.**
+- **Monitors restricted area access violations.**
+
+## Summary
+
+1. **Industrial Data Collection with KubeEdge**
+
+   - Supports **custom protocols** via `CustomizedProtocol` and `CustomizedValue`.
+   - Uses **ConfigMap** to manage edge **Mapper applications** from the cloud.
+   - **Bypass data (Spec/Data)** simplifies time-series data processing.
+
+2. **KubeEdge Productization**
+   - **Multi-tenant solutions**.
+   - **Enhanced monitoring strategies**.
+   - **High availability mechanisms**.
+   - **Public IP reuse solutions**.
+
+---
+
+To read this case study in Chinese language, please visit http://kubeedge.io/zh/case-studies/CAII.

--- a/src/pages/case-studies/CMCC-10086/index.mdx
+++ b/src/pages/case-studies/CMCC-10086/index.mdx
@@ -7,6 +7,175 @@ tags:
   - UserCase
 ---
 
-# China Mobile 10086 customer service cloud-edge collaboration platform based on KubeEdge
+# China Mobile 10086 Customer Service Cloud-Edge Collaborative Platform with KubeEdge
 
-For more detailed information, please visit http://kubeedge.io/zh/case-studies/CMCC-10086.
+## Evolution of China Mobile's Infrastructure
+
+### Introduction to China Mobile Online Marketing Service Center
+
+China Mobile's **Online Marketing Service Center** is a **second-tier professional institution** responsible for **managing online service resources and digital channels**. It operates the **world’s largest call center**, with:
+
+- **44,000 self-owned service seats**
+- **900 million users served**
+- **53 customer service centers**
+- **A leading position in customer service technology and business**
+
+![China Mobile Roadmap](/img/casestudies/CMCC-10086/roadmap.png)
+
+## Cloud-Native Strategy
+
+![Cloud-Native Strategy](/img/casestudies/CMCC-10086/cloud-native-route.png)
+
+## Cloud-Edge Collaboration Solution
+
+### **Requirements**
+
+China Mobile’s **integrated customer service system** is designed with **centralized call control and localized media access**. Due to **limited server capacity** at provincial branches, the infrastructure follows a **star topology** with **two central hubs and 31 provincial branches**.
+
+To improve **latency, audio/video transmission**, and user experience, **video customer service and voice portal services** are deployed **closer to the edge** at provincial branches. However, this approach introduced several **challenges**:
+
+1. **Slow business response:**
+
+   - Each provincial branch operates **independent resource pools**, leading to **low agility and inefficient resource sharing**.
+   - Limited ability to **scale workloads elastically**, affecting service stability.
+
+2. **Low operational efficiency:**
+
+   - Provincial deployments require **manual maintenance**, increasing **error rates and downtime**.
+
+3. **Low resource utilization:**
+   - Traditional **virtualization technology prevents efficient compute aggregation**.
+   - **Idle resources accumulate**, reducing overall efficiency.
+
+![Nationwide Deployment](/img/casestudies/CMCC-10086/nationwide-deployment.png)
+
+### **Cloud-Edge Collaboration Architecture Selection**
+
+A key challenge was **managing provincial branch nodes efficiently**. Two architectures were considered:
+
+- **Edge clusters** (full management resources, high performance, but high physical costs).
+- **Edge nodes** (leveraging cloud-side management, reducing overhead, and enabling direct control from the cloud).
+
+![Edge Cluster vs. Edge Node](/img/casestudies/CMCC-10086/edge-cluster-or-node.png)
+
+#### **Final Decision: Edge Node-Based Model**
+
+Since **provincial branches have limited server resources**, full-fledged **edge clusters would waste resources**. The **edge node model** was chosen, allowing:
+
+- **Cloud-based centralized control**.
+- **Offline autonomy**, ensuring service availability even in weak network conditions.
+- **Full compatibility with Kubernetes APIs**.
+
+## Cloud-Edge Collaboration Framework
+
+Using **KubeEdge**, China Mobile implemented a **“Central Hub + Edge Nodes”** model, extending containerized computing capabilities to edge locations while enabling **unified resource management**.
+
+![Network Architecture](/img/casestudies/CMCC-10086/network.png)
+
+**Key Capabilities:**
+
+- **Centralized Cluster Management:** Unified containerized service management.
+- **Edge Node Enrollment:** KubeEdge-based automated edge integration.
+- **Offline Autonomy:** Enhancements to EdgeCore ensure service resilience.
+- **CI/CD:** Reusing cloud-side DevOps capabilities for efficient deployment.
+- **Cloud-Edge Coordination:** Synchronizing **data, management, and maintenance**.
+
+## Implementation Challenges & Solutions
+
+### **Edge Networking**
+
+Multiple networking models were evaluated, and **Calico IP-in-IP** was chosen to maintain **isolated intra-branch traffic loops**.
+
+![Edge Networking](/img/casestudies/CMCC-10086/edge-network.png)
+
+### **Edge Resource Management**
+
+To avoid **resource fragmentation**, **resource pools** were established using **Kubernetes taints and tolerations**:
+
+![Edge Resource Management](/img/casestudies/CMCC-10086/edge-resource-management.png)
+
+- **Taint-based segmentation:** Isolates resources into dedicated pools.
+- **Flexible scheduling:** Assigns workloads dynamically based on priority.
+- **Optimized utilization:** Reduces redundancy and enhances emergency response capabilities.
+
+### **Edge Service Exposure & Traffic Handling**
+
+While **EdgeMesh** provides basic service exposure, **seven-layer load balancing was required**. A hybrid approach was adopted:
+
+![Service Discovery](/img/casestudies/CMCC-10086/service-discovery.png)
+
+- **East-West Traffic:** Downstream CoreDNS ensures domain resolution within branches.
+- **North-South Traffic:** Customized **Ingress Controllers** handle external requests.
+
+### **Service Traffic Isolation & Routing**
+
+![Traffic Topology](/img/casestudies/CMCC-10086/traffic-topology.png)
+
+- **Traffic Isolation:** Multi-tier **Ingress Controllers** allocate traffic efficiently.
+- **Segmented Deployments:** Minimizes fault impact across clusters.
+- **Canary Releases:** Gradual rollouts for new feature validation.
+- **Zero-Downtime Deployments:** Load-balanced auto-scaling ensures seamless upgrades.
+
+## **Optimizations**
+
+### **Hierarchical Image Registry**
+
+To mitigate **slow image downloads** at the edge, a **multi-tier image registry** was deployed:
+
+![Image Registry](/img/casestudies/CMCC-10086/image-registry.png)
+
+### **Federated Monitoring & Alerting**
+
+A **Prometheus + AlertManager + Grafana** monitoring stack was implemented:
+
+![Federated Monitoring](/img/casestudies/CMCC-10086/monitor.png)
+
+- **Decentralized data collection** at branches.
+- **Centralized visualization** via cloud-side Grafana.
+- **Aggregated alerts** using AlertManager.
+
+### **Offline IP Retention**
+
+Edge nodes **retain IP addresses even after disconnections**:
+
+![Offline IP Retention](/img/casestudies/CMCC-10086/offline-ip-retention.png)
+
+### **Edge Proxy for Offline Autonomy**
+
+To enhance **resilience**, an **Edge Proxy module** caches API requests:
+
+![Edge Proxy](/img/casestudies/CMCC-10086/edge-proxy.png)
+
+## **KubeEdge Community Contributions**
+
+China Mobile contributed several enhancements to KubeEdge:
+
+1. **keadm debug toolkit** – Debugging commands for easier edge issue diagnosis.
+2. **CloudCore memory optimization** – Reduced memory footprint by ~40%.
+3. **Default labels & taints for edge nodes** – Simplified deployment configuration.
+4. **Host resource reservation** – Prevents resource exhaustion at the edge.
+
+## **Conclusion & Future Directions**
+
+### **Summary**
+
+- **Enhanced Edge Management:** KubeEdge improved edge **resource control & service deployment**.
+- **Business-Centric Implementation:** Tailored solutions for **call center operations**.
+- **Optimized Service Exposure:** Integrated **customized networking and load balancing**.
+- **Resilient Monitoring & Automation:** Implemented **hierarchical image caching and federated monitoring**.
+- **Open-Source Contribution:** Actively improved KubeEdge with **community enhancements**.
+
+### **Future Roadmap**
+
+1. **Unified Compute Architecture:**
+
+   - Investigating **KubeVirt** for managing **both VMs and containers** at the edge.
+
+2. **Edge Middleware Management:**
+   - Exploring **operator-based management** for **databases & middleware** in unreliable networks.
+
+![Future Roadmap](/img/casestudies/CMCC-10086/k8s-kubeedge-kubevirt.png)
+
+China Mobile is committed to advancing **cloud-native edge computing** and welcomes more developers to contribute to the **KubeEdge community**.
+
+To read this case study in Chinese language, please visit http://kubeedge.io/zh/case-studies/CMCC-10086.

--- a/src/pages/case-studies/CMCC/index.mdx
+++ b/src/pages/case-studies/CMCC/index.mdx
@@ -7,6 +7,112 @@ tags:
   - UserCase
 ---
 
-# CMCC Panzhou Panji Platform base on KubeEdge
+# China Mobile PanZhou PanJi Platform KubeEdge Implementation
 
-For more detailed information, please visit http://kubeedge.io/zh/case-studies/CMCC.
+## Introduction
+
+The **PanZhou Integrated Cloud Delivery Platform** is a self-developed platform by **China Mobile**, designed for **code development, automated deployment, and continuous integration**. It features an **in-house GitOps engine** that enables seamless **application deployment on the PanJi container cloud platform**.
+
+The **PanJi container cloud platform** is an enterprise-grade **PaaS solution based on Kubernetes**, offering:
+
+- **Standardized Kubernetes capabilities**
+- **Development & runtime environments**
+- **Elastic resource scaling**
+- **Fine-grained microservice management**
+- **One-stop service deployment**
+- **Cross-region multi-cluster scheduling**
+- **Intelligent monitoring and maintenance**
+
+![PanJi Platform](/img/casestudies/CMCC/panji_platform.png)
+
+PanZhou and PanJi work **seamlessly together**:
+
+- Developers use **PanZhou clusters for development**.
+- Applications are **deployed on PanJi PaaS clusters**.
+- GitOps is used to **manage and deploy configurations** on PanJi clusters.
+
+![PanZhou PanJi Platform](/img/casestudies/CMCC/platform.png)
+
+## Managing Multi-Region Clusters
+
+With China Mobile’s **adoption of domestic infrastructure**, large-scale **Kunpeng-powered clusters** are deployed across multiple regions. **Key challenges include:**
+
+- **Managing 500+ ARM servers** while maintaining **dual-architecture (x86/ARM) support**.
+- **Frequent Kubernetes cluster operations**—over **800 cluster creations and deletions in two months**.
+- **Manual deployment bottlenecks**:
+  - Developers create images on **PanZhou Kubernetes clusters**.
+  - Manual deployment via **multi-hop SSH tunneling** to **province-level Kubernetes clusters**.
+  - Inefficient, non-automated workflow.
+
+### Key Considerations
+
+1. **Unifying Kubernetes clusters?**
+
+   - Not feasible due to **business-specific requirements** in each province.
+
+2. **Implementing Kubernetes Cluster Federation?**
+
+   - **High latency across provinces** makes federation **resource-intensive**.
+   - **Direct SSH access to province clusters is simpler**.
+
+3. **Maintaining manual SSH-based workflows?**
+   - **Manual shell script maintenance is inefficient**.
+   - **Not aligned with cloud-native best practices**.
+   - **Contradicts PanZhou-PanJi’s vision of seamless cloud migration**.
+
+## The "1+31+N" Model
+
+To improve **flexibility, automation, and efficiency**, China Mobile designed a **“1+31+N” network model**:
+
+- **1 central cluster**
+- **31 province-level clusters**
+- **N edge clusters**
+- **Network isolation between regions**
+
+This approach ensures **automated, cloud-native management** while maintaining **GitOps-based deployment** across clusters.
+
+To implement this, **KubeEdge was selected** as the core edge computing solution.
+
+## KubeEdge Implementation in PanZhou-PanJi
+
+By aligning **KubeEdge** with **China Mobile’s “1+31+N” model**, the architecture was mapped as follows:
+
+- **Central (Group-level) Kubernetes cluster** → KubeEdge **CloudCore**
+- **Province-level Kubernetes clusters** → KubeEdge **EdgeCore nodes**
+
+### **1) Cluster Deployment & GitOps Automation**
+
+- The **Group Kubernetes master node** acts as **CloudCore**.
+- **Province nodes** function as **EdgeCore**.
+- **ArgoCD pods** are deployed at the **EdgeCore** nodes.
+- GitOps **automates metadata distribution** across province-level clusters.
+
+### **2) Automated Cluster Creation**
+
+- **PanJi PaaS clusters** are automatically created at **province-level resource pools**.
+- Operators use **PanZhou GitOps** to deploy **OpenEuler-based Eggo tools**.
+- Eggo enables **automated Kubernetes cluster provisioning** at the **edge**.
+
+![KubeEdge Architecture](/img/casestudies/CMCC/cmcc_kubeedge_arch.png)
+
+## Results & Benefits
+
+By integrating **KubeEdge into the PanJi PaaS platform**, China Mobile successfully:
+
+- **Unified networking** across **1+31+N Kubernetes clusters**.
+- **Streamlined cluster management** and **reduced operational costs**.
+- **Automated provisioning** of **500+ Kunpeng ARM servers** and **BC-Linux for Euler clusters**.
+- **Significantly improved operational efficiency**.
+
+## Future Roadmap for Multi-Cluster Management
+
+Following the success of **KubeEdge integration**, China Mobile aims to:
+
+1. **Extend automation to control planes**
+   - Multi-node **southbound clusters** will be **automatically provisioned**.
+2. **Implement CNCF’s Karmada for Cluster Federation**
+   - Further improve **“1+31+N” multi-cluster unified management**.
+
+By leveraging **KubeEdge and Karmada**, China Mobile will continue to **enhance cloud-native multi-cluster orchestration** and **scale Kubernetes across its vast infrastructure**.
+
+To read this case study in Chinese language, please visit http://kubeedge.io/zh/case-studies/CMCC.

--- a/src/pages/case-studies/Kuiper/index.mdx
+++ b/src/pages/case-studies/Kuiper/index.mdx
@@ -7,6 +7,174 @@ tags:
   - Solution
 ---
 
-# Practice for processing edge streaming data with KubeEdge and Kuiper
+# Edge Streaming Data Processing with KubeEdge and Kuiper
 
-For more detailed information, please visit http://kubeedge.io/zh/case-studies/Kuiper.
+## Introduction
+
+KubeEdge is an open-source edge computing platform that extends Kubernetes' native container orchestration and scheduling capabilities to enable cloud-edge collaboration, compute offloading, large-scale edge device management, and edge autonomy. KubeEdge also supports 5G MEC, AI cloud-edge collaboration, and other scenarios through plugins. This article shares practical experiences of using KubeEdge and Kuiper for edge streaming data processing.
+
+## Kuiper: An Edge Streaming Processing Product
+
+Kuiper development began in early 2019, with its first version released in October 2019, and has continued to iterate ever since. Its architecture follows a classic streaming processing design.
+
+### Product Design Goal:
+
+Enable streaming processing at the edge, similar to how Spark and Flink operate in the cloud.
+
+![Kuiper Architecture](/img/casestudies/kuiper/kuiper_architecture.png)
+
+The overall architecture consists of three main parts:
+
+- **Sources (left)**: Data input sources, such as the MQTT broker in KubeEdge's edge layer, files, databases, or windows.
+- **Sinks (right)**: Data output destinations, including MQTT, files, databases, or HTTP services.
+- **Processing Layer (middle)**:
+  - **Business Logic Layer**: Handles SQL statements, rule parsing, and SQL plan conversion.
+  - **Streaming & SQL Runtime**: Executes the processing plan.
+  - **Storage Layer**: Stores outgoing message streams.
+
+## Kuiper Use Cases
+
+- **Streaming Processing**: Real-time data streaming processing at the edge.
+- **Rule Engine**: Define flexible rule-based processing, including alerts and message forwarding.
+- **Data Format & Protocol Conversion**: Bridge different data formats and protocols between the edge and cloud for IT & OT integration.
+
+![KubeEdge & Kuiper Integration](/img/casestudies/kuiper/kubeedge&kuiper.png)
+
+Kuiper runs behind the **KubeEdge MQTT Broker**, operating entirely at the edge. Below it, various **Mappers** connect different protocols. The **Edge MQTT Broker** facilitates message exchange.
+
+### Types of Data Processing:
+
+- Extracting data definitions from device model files.
+- Converting data to Kuiper-supported types.
+- Using schema-less stream definitions when creating data streams.
+- Supported data types: `int`, `string`, `bool`, `float`.
+
+## KubeEdge Model Files & Configuration
+
+The following configuration file defines device attributes, including name, data type, and description.
+
+![Configuration File](/img/casestudies/kuiper/configuration.png)
+
+### Storing Device Model Files
+
+- Model file details are configured in `ect/mqtt_source.yaml`.
+- Configuration options:
+  1. **KubeEdgeVersion**: Reserved for future model file versions.
+  2. **KubeEdgeModelFile**: Specifies the model file path.
+- Configurations are delivered via **ConfigMap**, saving them in the required directory.
+
+## Kuiper Usage Process
+
+### 1) Define a Stream
+
+A stream definition is similar to a database table schema.
+
+- **DATASOURCE**: Set to `"$hw/events/device/+/twin/update"`, a pre-defined topic in KubeEdge.
+
+![Stream Definition](/img/casestudies/kuiper/stream.png)
+
+### 2) Define and Submit Rules
+
+![Rule Definition](/img/casestudies/kuiper/rules.png)
+
+Business logic is implemented using SQL, and results are sent to a designated target.
+
+#### Supported SQL Syntax:
+
+```sql
+SELECT/FROM/WHERE/ORDER
+JOIN/GROUP/HAVING
+```
+
+#### Supported Features:
+
+- **Four types of time windows** + **One count-based window**
+- **60+ SQL functions**
+
+### 3) Execute Processing
+
+## Deploying Kuiper Rules in KubeEdge
+
+### 1) Using Kuiper-Kubernetes-Tool
+
+- This standalone tool runs in a container and executes command configurations delivered via **ConfigMap**.
+- Configuration file specifies Kuiper service address, ports, and command locations.
+- The tool periodically scans and executes commands from the **ConfigMap**.
+
+### 2) Managing Kuiper via Cloud-Edge Coordination
+
+Another approach is to use a **management console** to oversee multiple Kuiper nodes.
+
+![Multiple Kuiper Nodes](/img/casestudies/kuiper/multiple_nodes.png)
+
+For example, in **vehicle networking**, Kuiper instances run inside vehicle-mounted edge boxes. The **Kuiper Manager** centralizes rule updates for all instances.
+
+1. **Install Plugins**: Custom plugins can be installed for integrating unsupported data sources.
+
+![Android Plugin](/img/casestudies/kuiper/android_plugin.png)
+
+2. **Create Stream Definitions**:
+
+![Stream Definition Example](/img/casestudies/kuiper/demo_stream.png)
+
+3. **Define Data Storage Location**:
+
+![Target Attribute](/img/casestudies/kuiper/target_attribute.png)
+
+4. **Use a Visual Rule Editor** to define rules interactively.
+
+![Rule Writing Interface](/img/casestudies/kuiper/write_rules.png)
+
+## Use Case: National Industrial Internet Big Data Center
+
+![Big Data Center](/img/casestudies/kuiper/big_data_center.png)
+
+In this case study, **K8s + CloudCore** is deployed in the cloud, and rules are distributed to **Kuiper** via the management channel. Kuiper is placed behind the **MQTT Broker** to handle **data processing and cleansing**. Two processing channels are used:
+
+1. **Forwarding processed messages** to the **Cloud MQTT Broker**.
+2. **Persisting local data** using **InfluxDB**, allowing third-party applications to access and visualize data.
+
+## Kuiper Rule Engine in LF EdgeX Foundry
+
+Kuiper is integrated into **LF EdgeX Foundry** as a built-in rule engine, officially released in the **April 2020 Geneva version**.
+
+![LF EdgeX Foundry](/img/casestudies/kuiper/edgex_foundry.png)
+
+![EdgeX Foundry Integration](/img/casestudies/kuiper/edgex_foundry2.png)
+
+## Use Case: Data Format Conversion for Heterogeneous Systems
+
+Kuiper enables data exchange between **ERP, MES, and other IT systems** with flexible extensions:
+
+- Data from **heterogeneous sources** can be **collected via custom plugins** and processed using **SQL functions**.
+- The **sink module** formats processed data for different target systems.
+- Example: A **temperature >30°C** alert might need:
+  - **One action to control a device**.
+  - **Another to send an alert via WeChat**.
+- Using Kuiper, both can be triggered **from the same rule**, eliminating redundant programming.
+
+## Performance Metrics
+
+### Kuiper Supports Thousands of Concurrent Rules
+
+- **8000 rules × 0.1 messages/sec per rule = 800 TPS**.
+
+```sql
+Source: MQTT
+SQL: SELECT temperature FROM source WHERE temperature > 20 (90% data filtered)
+Target: Log
+```
+
+#### Test Configuration:
+
+- **AWS:** 2-core, 4GB RAM
+- **Ubuntu OS**
+- **Resource Usage:**
+  - **Memory**: 0.4MB per rule (72%-89% utilization)
+  - **GPU**: 25%
+
+### AWS t2.micro Handling 10K+ Messages/Sec
+
+![AWS Throughput](/img/casestudies/kuiper/aws.png)
+
+To read this case study in Chinese language, please visit http://kubeedge.io/zh/case-studies/Kuiper.

--- a/src/pages/case-studies/SF-Tech/index.mdx
+++ b/src/pages/case-studies/SF-Tech/index.mdx
@@ -7,6 +7,80 @@ tags:
   - UserCase
 ---
 
-# The practice of KubeEdge in SF Technology Industrial Internet of Things(IIoT)
+# Application of KubeEdge Edge Computing in SF Tech's Industrial IoT
 
-For more detailed information, please visit http://kubeedge.io/zh/case-studies/SF-Tech.
+## Development of Industrial IoT and Edge Computing
+
+Industrial IoT (IIoT) was first introduced by **General Electric (GE)** in 2012 with the launch of the **Predix platform**. In China, the government published the **Smart Manufacturing Development Plan (2016-2020)** in 2015, emphasizing major strategies in intelligent manufacturing. By September 2020, China further accelerated **digital transformation** among state-owned enterprises. As an enabler of **smart manufacturing and Industry 4.0**, Industrial IoT requires the **convergence of Operational Technology (OT) and Information Technology (IT)**. However, integrating these two domains presents several challenges, primarily in the following aspects:
+
+- **Differences between OT and IT:**
+  - OT prioritizes **stability and reliability**, and OT personnel tend to avoid frequent changes to running systems.
+  - IT focuses on **data processing speed, system reliability, and security**, requiring continuous innovation to keep up with evolving technologies.
+- **Organizational and Implementation Challenges:**
+  - Who should lead the integration?
+  - What is the implementation scope?
+  - What measurable benefits can be achieved?
+
+![OT vs IT Technologies](/img/casestudies/sf-tech/OT-IT.png)
+
+As the **bridge between OT and IT**, Industrial IoT relies on multiple supporting technologies, including **industrial automation, sensor networks, ubiquitous connectivity, edge computing, cloud computing, big data analytics, and industrial data modeling**. These components collectively build the **Industrial IoT ecosystem**.
+
+![Industrial IoT Supporting Framework](/img/casestudies/sf-tech/IIOT-system.png)
+
+Industrial IoT architecture varies based on use cases but generally consists of five layers:
+
+- **Perception Layer**: Responsible for **data acquisition** from industrial equipment, sensors, and heterogeneous systems.
+- **Edge Computing Layer**: Handles **real-time processing, analysis, and data filtering** before transmitting data to higher layers.
+- **Network Layer**: Establishes **wired or wireless connectivity** between edge nodes and cloud infrastructure.
+- **Platform Layer**: Provides **Industrial PaaS capabilities** such as data ingestion, analytics, and application templates.
+- **Application Layer**: Delivers **business-specific solutions**, integrating with ERP, WMS, CRM, and other enterprise systems to eliminate data silos.
+
+![Industrial IoT Architecture](/img/casestudies/sf-tech/IIOT-arch.png)
+
+## Three Key Problems Addressed by Edge Computing in IIoT
+
+Currently, **edge computing** in Industrial IoT aims to address the following challenges:
+
+1. **Real-time Data Processing**: Ensuring real-time monitoring and control in industrial operations. **SF Tech** has actively explored OT-IT integration and IIoT applications, overcoming obstacles related to **network infrastructure, personnel training, cost, and legacy system compatibility**.
+2. **Network Security and Reliability**: Addressing concerns such as **limited bandwidth, connectivity disruptions, and cybersecurity risks**.
+3. **Trends Driving Adoption**:
+   - **Increased device connectivity** across industrial environments.
+   - **Growing demand for efficiency, quality, and cost optimization**.
+   - **The gradual convergence of OT and IT ecosystems**.
+
+## How SF Tech Solves These Challenges
+
+Given the **convergence of OT and IT**, how can we leverage **cloud-edge collaboration, edge data collection, and edge data cleansing** to meet the demands of real-time decision-making and security?
+
+Industrial operations inherently require **real-time processing**. The **adoption of edge computing** is becoming natural as **hardware processing capabilities improve**. However, OT systems often lack agility, and industrial **automation control systems** remain heavily reliant on **on-site engineering teams**. Deployment, upgrades, and system modifications in traditional **single-machine architectures** can cause significant disruptions.
+
+### **Key Benefits of Edge Computing**
+
+- **Integrates OT and IT** while ensuring system stability.
+- **Reduces latency** by processing data closer to its source.
+- **Enhances security** by limiting exposure to cloud environments.
+- **Supports automation** without disrupting existing workflows.
+
+![Edge Computing: The Bridge Between OT and IT](/img/casestudies/sf-tech/edgecomputing-OT.png)
+
+## Application of KubeEdge in SF Tech
+
+To implement edge computing, **SF Tech** adopted **KubeEdge**, an open-source edge computing platform, as the foundation for **edge node management and edge application orchestration**. Building on its **expertise in IoT device management and data processing**, SF Tech established a **leading framework for cloud-edge collaboration**.
+
+![KubeEdge Open Source Framework](/img/casestudies/sf-tech/kubeedge-arch.png)
+
+### **Key Achievements**
+
+1. **Built a pervasive sensing network**:
+   - Directly connects to heterogeneous industrial devices.
+   - Bridges gaps between OT production systems and IT environments.
+2. **Applied IoT technology to logistics and supply chains**:
+   - Enhanced automation in sorting centers.
+   - Improved tracking and monitoring across transport networks.
+3. **Standardized digital monitoring and intelligent management**:
+   - Supported automated production and efficiency control.
+   - Strengthened data-driven decision-making.
+
+Ultimately, **SF Tech's Industrial IoT architecture** enables **continuous digital transformation** by improving automation, reducing costs, and driving operational excellence.
+
+To read this case study in Chinese language, please visit http://kubeedge.io/zh/case-studies/SF-Tech.

--- a/src/pages/case-studies/ctyun/index.mdx
+++ b/src/pages/case-studies/ctyun/index.mdx
@@ -7,6 +7,141 @@ tags:
   - UserCase
 ---
 
-# ctyun’s large-scale CDN scenario implementation practice based on KubeEdge
+# Tianyi Cloud's Large-Scale CDN Implementation Based on KubeEdge
 
-For more detailed information, please visit http://kubeedge.io/zh/case-studies/ctyun.
+## Tianyi Cloud CDN Cloudification Project
+
+### Tianyi Cloud CDN Business
+
+China Telecom accelerates cloud-network integration with a "2+4+31+X" resource layout. "X" is the access layer, which puts content and storage closest to users, making the network move with the cloud, convenient cloud access, and smooth access between clouds, meeting users' on-demand selection and low latency requirements. Although Tianyi Cloud CDN started late, it currently has all the basic CDN functions, rich resource reserves, supports precise scheduling, and adheres to quality first. The overall business development is entering the fast lane.
+
+### Business Background
+
+## Edge Service Containerization
+
+Unlike other cloud vendors and traditional CDN vendors, Tianyi Cloud CDN started late, but it also coincided with the popularization of the cloud-native concept. Therefore, we chose to build a CDN PaaS platform through containers and k8s orchestration technology, but the CDN edge service has not yet completed the cloud-native transformation.
+
+![Service Containerization](/img/casestudies/ctyun/serviceContainer.png)
+
+### Existing Problems:
+
+1. **How to manage CDN nodes distributed on the edge on a large scale?**
+2. **How to reliably deploy and upgrade CDN edge services?**
+3. **How to build a unified and scalable resource scheduling platform?**
+
+## Edge Node Management with KubeEdge
+
+### CDN Physical Node Architecture
+
+The cache acceleration service provided by CDN solves the last mile acceleration problem. To meet the needs of nearby access and fast response, most CDN nodes need to be deployed close to the user side, and the user access is connected to the nearest node through the CDN global traffic scheduling system. Usually, CDN nodes are distributed in a discrete manner, and most of them are based on regional IDC and prefecture-level IDC computer room resources. Each edge computer room builds multiple CDN service clusters based on the export bandwidth and server resource planning.
+
+![Physical Node Architecture](/img/casestudies/ctyun/nodeArchitecture.png)
+
+### Edge Service Containerization Technology Selection
+
+When considering containerization, we conducted technical selection and research in the early stage, mainly in three directions:
+
+- **Standard K8s**: Edge nodes are added to the master as standard worker nodes, but this method also has problems. If there are too many connections, it is easy to cause relist issues, and the load pressure on the k8s master is high. Network fluctuations cause pods to be expelled, resulting in unnecessary reconstruction.
+- **Independent Edge Clusters**: Deploying K8s or K3s separately for edge nodes. This method results in multiple control planes and fragmented scheduling platforms, requiring additional high-availability node redundancy.
+- **KubeEdge-based Cloud-Edge Access**: By using KubeEdge, we can consolidate edge node connections, integrate them into a unified K8S cluster, and provide cloud-edge collaboration and autonomy while retaining most native K8s functionalities.
+
+### KubeEdge-Based Edge Node Management Plan
+
+![Edge Node Management Plan](/img/casestudies/ctyun/managementPlan.png)
+
+The architecture above shows how we deployed multiple Kubernetes clusters in regional centers and data centers, ensuring edge nodes connect to the closest available cluster. To avoid single-point failures and excessive cloudcore load, we established distributed K8s clusters for edge node access and application orchestration.
+
+## CloudCore Multi-Replica Deployment and Connection Imbalance
+
+![Unbalanced Connection](/img/casestudies/ctyun/unbalancedConnection.png)
+
+- The **hub-to-upstream module** runs in a **single-threaded** mode, causing **delays in message submissions**.
+- Some **edge nodes fail to submit updates to the API server**, leading to deployment inconsistencies.
+- **CloudCore upgrades or restarts** result in **connection imbalances** due to ineffective load balancing.
+
+### Optimizing CloudCore Multi-Replica Load Balancing
+
+1. Each CloudCore instance **reports real-time connection counts** via ConfigMap.
+2. CloudCore calculates expected connections per instance.
+3. If an instance exceeds the tolerable limit, it enters a **30s observation phase** before redistributing connections.
+4. The cycle continues until **connection balancing is achieved**.
+
+![Connection Changes](/img/casestudies/ctyun/connectionChanges.png)
+![Balance After Restart](/img/casestudies/ctyun/equilibriumSituation.png)
+
+## CDN Acceleration Service Deployment
+
+### CDN Workflow Overview
+
+CDN consists of two core systems: **scheduling and caching**.
+
+1. The **scheduling system** collects network and bandwidth cost metrics to determine optimal traffic routing.
+2. The **caching system** ensures content is stored at edge nodes to minimize latency.
+3. Cache **misses** lead to fallback requests to upstream caches or the origin server.
+
+![CDN Workflow](/img/casestudies/ctyun/overallProcess.png)
+
+### Challenges in CDN Caching:
+
+1. **Ensuring controlled and sequential upgrades of edge node containers.**
+2. **Implementing A/B testing for version rollouts.**
+3. **Validating and monitoring the upgrade process.**
+
+### Upgrade Deployment Strategy
+
+1. **Batch Upgrades & In-Group Parallelism**
+   - Define **upgrade tasks**.
+   - Upgrade designated machines in phases.
+2. **Granular Version Control**
+   - Map **versions at the host level**.
+   - Enable version-based pod selection.
+3. **Graceful Upgrades**
+   - Utilize **lifecycle hooks (preStop/postStart)** for traffic redirection.
+   - Leverage **GSLB-based traffic shifting** in special cases.
+4. **Upgrade Validation & Rollback**
+   - Integrate monitoring and rollback triggers upon anomalies.
+   - Use **Admission Webhooks** to enforce upgrade policies.
+
+![Upgrade Plan](/img/casestudies/ctyun/upgradePlan.png)
+
+## CDN Edge Container Disaster Recovery & Migration
+
+Migration Steps:
+
+1. **Backup etcd and restore it in the new cluster**.
+2. **Switch DNS access**.
+3. **Restart CloudCore to disconnect cloud-edge hubs**.
+
+![Disaster Recovery & Migration](/img/casestudies/ctyun/recoveryMigration.png)
+
+## Large-Scale CDN File Distribution
+
+**Use Cases:**
+
+- **CDN edge service configurations**
+- **GSLB scheduling decision data**
+- **Container image preloading tasks**
+
+![File Distribution](/img/casestudies/ctyun/fileDistribution.png)
+
+## Future Evolution of CDN Edge Computing
+
+### Challenges
+
+- **Diverse architectures & resources**
+- **Network latency and reliability constraints**
+- **Security concerns in edge computing**
+- **Diverse business use cases**
+
+### Evolution Goals
+
+- **CDN & Edge Node Hybrid Deployment**
+- **Service Mesh for edge networking**
+- **CDN gateway as an ingress controller**
+- **CDN resource virtualization**
+- **Serverless containerized edge platforms**
+- **Unified CDN & container resource scheduling**
+
+---
+
+To read this case study in Chinese language, please visit http://kubeedge.io/zh/case-studies/ctyun.

--- a/src/pages/case-studies/zcitc/index.mdx
+++ b/src/pages/case-studies/zcitc/index.mdx
@@ -7,6 +7,140 @@ tags:
   - UserCase
 ---
 
-# ZCITC practice in smart parking base on KubeEdge
+# Introduction
 
-For more detailed information, please visit http://kubeedge.io/zh/case-studies/zcitc.
+As urban parking resources continue to expand and application scenarios diversify, **edge applications** are becoming increasingly complex. The rapid growth in **edge nodes** and the data they generate presents **several challenges in managing edge applications**:
+
+1. **Complex Network Topologies & Unstable Connectivity**:
+
+   - Retrofitting old parking lots with smart systems and constructing new smart parking lots require careful **network planning** based on project requirements, physical location, and road layout.
+   - Some large parking lots can deploy **dedicated fiber-optic lines**, while others may rely on **mobile networks** due to **physical restrictions on cable installation**.
+   - Network quality varies, and municipal construction may **occasionally cause power or network outages**, affecting system availability.
+
+2. **Highly Customized Demands & Frequent Updates**:
+
+   - Urban platforms integrate various parking resources, including **public street parking, commercial lots, residential spaces, and redeveloped zones**.
+   - Different **sensing technologies, operators, and pricing policies** make a **one-size-fits-all parking application infeasible**.
+   - Even after construction, **customizations and updates** are needed to accommodate events like **promotional discounts, special period pricing, and business collaborations**.
+   - Parking applications must support **version control, extensibility, and flexible deployment**.
+
+3. **Heterogeneous Edge Gateway Hardware Challenges**:
+   - Parking lots vary in scale, leading to **different computational needs**.
+   - Small lots may have **a single lane with a few spaces**, while larger lots feature **multiple entrances, hundreds of spaces, and zone-based pricing**.
+   - Gateways use different **CPU architectures** (x86_64, aarch32, aarch64), increasing technical complexity and management overhead.
+
+Zhejiang Zhicheng Software Co., Ltd. specializes in **urban-scale integrated smart parking solutions**. To support **unattended parking management**, the **Zhicheng team increasingly deploys containerized applications at edge nodes** to enhance security, reliability, efficiency, and maintainability.
+
+# Cloud-Native Edge Computing Technology
+
+Edge computing **decentralizes computation**, shifting workloads from cloud data centers to edge nodes, reducing latency and improving **real-time processing**.
+
+- **Cloud-native** methodologies (Kubernetes + Docker) enable flexible, scalable, and automated edge application management.
+- **Microservice architecture** enhances **modularity and maintainability**.
+- **DevOps & CI/CD** support continuous iteration and automated deployment.
+
+As computational scale and complexity increase, **cloud-native edge computing** is emerging as a key trend. **KubeEdge**, based on Kubernetes, is a leading **cloud-native edge computing framework**.
+
+![KubeEdge Architecture](/img/casestudies/zcitc/kubeedgeArchitecture.png)
+
+# Smart Parking System Architecture Based on Cloud-Native Edge Computing
+
+## Overall Architecture
+
+The **integrated urban parking platform** aims to unify street and off-street parking resources, merge **static and dynamic traffic data**, and create an **open ecosystem** for parking operators and users. Zhicheng **containerized all parking services**, deploying them **dynamically across cloud and edge nodes**.
+
+![System Structure](/img/casestudies/zcitc/systemStructure.png)
+
+## Technical Implementation
+
+KubeEdge extends Kubernetes' **application orchestration** capabilities to the edge, ensuring **high availability** and support for **complex parking services**.
+
+![Kubernetes Cluster](/img/casestudies/zcitc/KubernetesCluster.png)
+
+The **parking edge layer** consists of **loosely coupled containerized applications**, leveraging **Kubernetes and KubeEdge** for service deployment.
+
+![Edge Architecture](/img/casestudies/zcitc/EdgeArchitecture.png)
+
+### Key Components at the Edge:
+
+1. **Core Services**:
+
+   - **PostgreSQL** stores business data.
+   - **Redis** functions as an LRU cache to reduce disk I/O.
+   - **Zabbix** monitors system health.
+   - **Zeroconf Service** provides **gateway discovery** for operator terminals.
+
+2. **Gateway Broker**:
+
+   - Manages **message subscription, publishing, and bidirectional communication** between the edge and cloud.
+
+3. **Device Integration Layer**:
+
+   - Includes **camera, barrier gate, parking space display, voice alerts, and vehicle detection modules**.
+
+4. **Storage & Upload Services**:
+
+   - **StorageService** handles **image and video persistence**.
+   - **DiskUsageService** monitors disk capacity.
+   - **UploadService** manages **priority-based data uploads**.
+
+5. **Business Applications**:
+   - **Order management, entrance control, and fee calculations**.
+
+## Key Deployment Strategies
+
+1. **Master-Slave Edge Database Configuration**:
+   - Large parking lots (e.g., shopping malls, stadiums) require **multi-node failover setups**.
+   - Deploy **PostgreSQL and Redis using StatefulSets** for persistent storage across nodes.
+
+![Master-Slave Deployment](/img/casestudies/zcitc/MasterSlave.png)
+
+2. **Active-Active Redundancy**:
+
+   - Use **ReplicaSets** for **automatic failover and load balancing**.
+
+3. **Affinity Scheduling for Related Applications**:
+
+   - **ParkingLotService** and **DeviceService** are deployed **on the same node** for optimal performance.
+
+4. **Cross-Node Instance Deployment**:
+
+   - Applications like **ParkingLotService** run multiple instances across nodes for **high availability**.
+   - Small-scale parking lots can **deploy cloud-based backups**.
+
+5. **Node-Based Deployment Groups**:
+
+   - Parking lots use different hardware (x86_64, aarch32, aarch64).
+   - Applications are deployed using **NodeSelector** labels to match hardware architectures.
+
+6. **Automated Node Onboarding**:
+
+   - New edge nodes **automatically inherit deployment configurations** when joining the cluster.
+
+7. **Multi-Parking Lot Coordination**:
+   - **EdgeMesh** facilitates **real-time inter-lot communication** for:
+     - **Shared vehicle entry/exit tracking**.
+     - **Cross-lot payment processing**.
+     - **Real-time road traffic guidance integration**.
+
+# Implementation Results
+
+The **Zhicheng Smart Parking OS** supports **x86_64, aarch32, and aarch64 CPU architectures**, adapting to various parking scales and cost structures. MQTT-based **lightweight communication** reduces **bandwidth usage**.
+
+### Cloud-Edge Benefits:
+
+1. **Smart Device Integration**: Connects **cameras, sensors, and control units**.
+2. **Bidirectional Data Sync**: Real-time data exchange between **edge and cloud**.
+3. **Short-Term Offline Operation**:
+   - Vehicles can still **enter/exit**, process **white-listed vehicles**, and compute **offline payments**.
+   - Data automatically syncs upon **network recovery**.
+4. **Load Balancing & High Availability**:
+   - Supports **“single-node multi-active” and “cloud-edge redundancy”**.
+5. **Continuous Deployment & Rapid Updates**:
+   - **Full-containerized applications** enable **automated deployments, updates, and rollbacks**.
+
+# Conclusion
+
+Unattended parking services and **online parking management** remain **early-stage growth areas**, delivering **cost savings and efficiency improvements**. Moving forward, **Zhicheng** will continue leveraging **IoT and edge computing** to enhance parking operations, **increase parking turnover, reduce labor costs, and optimize overall revenue**.
+
+To read this case study in Chinese language, please visit http://kubeedge.io/zh/case-studies/zcitc.


### PR DESCRIPTION

**Which issue(s) this PR fixes**:

Fixes #692 

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix (Case Study Blog issue)

* **What is the current behavior?** ([Issue ](https://github.com/kubeedge/website/issues/692))
Currently, several case study pages on the KubeEdge website default to Chinese because their Markdown content is in Chinese.
When users attempt to switch to English using the navigation dropdown, they are redirected to the page containing the case study links instead of the translated content.

**Affected Case Studies :**

[CMCC Panzhou Panji Platform](https://kubeedge.io/zh/case-studies/cmcc/)
[SF Tech](https://kubeedge.io/zh/case-studies/sf-tech/)
[ZCITC](https://kubeedge.io/zh/case-studies/zcitc/)
[CTYun](https://kubeedge.io/case-studies/ctyun/)
[CAII](https://kubeedge.io/zh/case-studies/caii/)
[Kuiper](https://kubeedge.io/zh/case-studies/kuiper/)


* **What is the new behavior (if this is a feature change)?**

The Markdown content for the affected case studies has been translated into English, ensuring that users can directly read the content in English without relying on Google Translate or encountering redirections.

**Screenshot**

![image](https://github.com/user-attachments/assets/8ff1d9fa-a14d-4ded-a31c-15a989a0b3d9)

![image](https://github.com/user-attachments/assets/5cac328b-1b67-433c-ae3b-19eaabcc3dcc)

**............**
* **Does this PR introduce a breaking change?**

No, this PR does not introduce any breaking changes.




