### PR TITLE
Update Broken Links in EdgeHub Docs + Fix Bullet Points Formatting in Edge Controller Docs

### DIFF
--- a/docs/architecture/cloud/edge_controller.md
+++ b/docs/architecture/cloud/edge_controller.md
@@ -33,17 +33,17 @@ The following are the functions performed by Edge controller:
 - Creates message channel to update Nodestatus, Podstatus, Secret and configmap related events
 - Gets pod condition information like Ready, Initialized, Podscheduled and Unschedulable details
 - **Below is the information for PodCondition**
-   - **Ready**: PodReady means the pod is able to service requests and should be added to the load balancing pools for all matching services
-   - **PodScheduled**: It represents the status of the scheduling process for this pod
-   - **Unschedulable**: It means the scheduler cannot schedule the pod right now, maybe due to insufficient resources in the cluster
-   - **Initialized**: It means that all Init containers in the pod have started successfully
-   - **ContainersReady**: It indicates whether all containers in the pod are ready
+  - **Ready**: PodReady means the pod is able to service requests and should be added to the load balancing pools for all matching services
+  - **PodScheduled**: It represents the status of the scheduling process for this pod
+  - **Unschedulable**: It means the scheduler cannot schedule the pod right now, maybe due to insufficient resources in the cluster
+  - **Initialized**: It means that all Init containers in the pod have started successfully
+  - **ContainersReady**: It indicates whether all containers in the pod are ready
 - **Below is the information for PodStatus**
-   - **PodPhase**: Current condition of the pod
-   - **Conditions**: Details indicating why the pod is in this condition
-   - **HostIP**: IP address of the host to which pod is assigned
-   - **PodIp**: IP address allocated to the Pod
-   - **QosClass**: Assigned to the pod based on resource requirement
+  - **PodPhase**: Current condition of the pod
+  - **Conditions**: Details indicating why the pod is in this condition
+  - **HostIP**: IP address of the host to which pod is assigned
+  - **PodIp**: IP address allocated to the Pod
+  - **QosClass**: Assigned to the pod based on resource requirement
 
    ![Upstream Controller](/img/edgecontroller/UpstreamController.png)
 
@@ -54,6 +54,6 @@ The following are the functions performed by Edge controller:
 - Manages OnAdd, OnUpdate and OnDelete events which will be updated to the respective edge node from the K8s Api-server
 - Creates an eventManager(configMaps, pod, secrets) which will start a CommonResourceEventHandler, NewListWatch and a newShared Informer for each event to sync(add/update/delete)event(pod, configmap, secret) to edgecore via cloudHub
 - **Below is the List of handlers created by the controller Manager**
-   - **CommonResourceEventHandler**: NewcommonResourceEventHandler creates CommonResourceEventHandler which is used for Configmap and pod Manager
-   - **NewListWatch**: Creates a new ListWatch from the specified client resource namespace and field selector
-   - **NewSharedInformer**: Creates a new Instance for the Listwatcher
+  - **CommonResourceEventHandler**: NewcommonResourceEventHandler creates CommonResourceEventHandler which is used for Configmap and pod Manager
+  - **NewListWatch**: Creates a new ListWatch from the specified client resource namespace and field selector
+  - **NewSharedInformer**: Creates a new Instance for the Listwatcher

--- a/docs/architecture/edge/edgehub.md
+++ b/docs/architecture/edge/edgehub.md
@@ -73,5 +73,5 @@ The major steps involved in this process are as follows :-
 
 EdgeHub can be configured to communicate in two ways as mentioned below:
 
-- **Through websocket protocol**: Click [here](https://github.com/kubeedge/kubeedge/tree/master/docs/proposals/quic-design.md#edgehub-connect-to-cloudhub-through-websocket-protocol) for details.
-- **Through QUIC protocol**: Click [here](https://github.com/kubeedge/kubeedge/tree/master/docs/proposals/quic-design.md#edgehub-connect-to-cloudhub-through-quic) for details.
+- **Through websocket protocol**: Click [here](https://github.com/kubeedge/kubeedge/blob/master/docs/proposals/sig-architecture/quic-design.md#edgehub-connect-to-cloudhub-through-websocket-protocol) for details.
+- **Through QUIC protocol**: Click [here](https://github.com/kubeedge/kubeedge/blob/master/docs/proposals/sig-architecture/quic-design.md#edgehub-connect-to-cloudhub-through-quic) for details.


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubeedge/kubeedge/issues/6427

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR does two things:
- fixes incorrect links in the [EdgeHub#usage](https://kubeedge.io/docs/architecture/edge/edgehub#usage) section of the docs
- fixes incorrect formatting of bullet points in the [Edge Controller#upstream-controller](https://kubeedge.io/docs/architecture/cloud/edge_controller#upstream-controller) and [Edge Controller#controller-manager](https://kubeedge.io/docs/architecture/cloud/edge_controller#controller-manager) sections of the docs


**What is the current behavior?** (You can also link to an open issue here)

Incorrect links in the [EdgeHub#usage](https://kubeedge.io/docs/architecture/edge/edgehub#usage) section of the docs direct readers to pages which no longer exist, such as https://github.com/kubeedge/kubeedge/tree/master/docs/proposals/quic-design.md#edgehub-connect-to-cloudhub-through-websocket-protocol:
<img width="1203" height="341" alt="image" src="https://github.com/user-attachments/assets/3f27e015-3d81-44de-b616-bdd7b37e35e1" />

Formatting has not been applied to bullet points in the [Edge Controller#upstream-controller](https://kubeedge.io/docs/architecture/cloud/edge_controller#upstream-controller) and [Edge Controller#controller-manager](https://kubeedge.io/docs/architecture/cloud/edge_controller#controller-manager) sections of the docs:
<img width="984" height="474" alt="image" src="https://github.com/user-attachments/assets/cf015adf-7e66-4a60-94d9-340f18c3b5e7" />

<img width="986" height="410" alt="image" src="https://github.com/user-attachments/assets/5ff632bc-f5ac-42a3-953e-3c60fe3af63a" />

**What is the new behavior (if this is a feature change)?**

I've updated the broken links in the EdgeHub docs to point to the correct docs:
- https://github.com/kubeedge/kubeedge/blob/master/docs/proposals/sig-architecture/quic-design.md#edgehub-connect-to-cloudhub-through-websocket-protocol
- https://github.com/kubeedge/kubeedge/blob/master/docs/proposals/sig-architecture/quic-design.md#edgehub-connect-to-cloudhub-through-quic

and also adjusted the Edge Controller docs such that the bullet points formatting is applied as expected as can be seen in the below images:
<img width="991" height="638" alt="image" src="https://github.com/user-attachments/assets/56abdba5-9a7c-4ea6-bb43-b43029200ed6" />
<img width="971" height="420" alt="image" src="https://github.com/user-attachments/assets/25043e42-2256-441f-a1a9-ce89a67d496d" />
**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

**Other information**:
