### PR TITLE
docs: fix broken Slack links and improve accessibility for new users … #714

### DIFF
--- a/docs/community/slack.md
+++ b/docs/community/slack.md
@@ -5,16 +5,19 @@ sidebar_position: 7
 
 # Join the KubeEdge Slack Community
 
-The KubeEdge community collaborates on the **CNCF Slack workspace**.  
+The KubeEdge community collaborates on the **CNCF Slack workspace**.
+
 If you’re new, follow these steps to get started:
 
 ## Step 1: Create/Join CNCF Slack
-- Go to [slack.cncf.io](https://slack.cncf.io/)  
-- Sign in with your email (or create a new account if you don’t already have one).  
+
+- Go to [slack.cncf.io](https://slack.cncf.io/)
+- Sign in with your email (or create a new account if you don’t already have one).
 - You’ll be added to the **Cloud Native Computing Foundation (CNCF)** Slack workspace.
 
 ## Step 2: Find KubeEdge Channels
-Once inside CNCF Slack, use the search bar to find and join the KubeEdge channels below.  
+
+Once inside CNCF Slack, use the search bar to find and join the KubeEdge channels below.
 
 | Channel | Purpose |
 |---------|---------|
@@ -32,8 +35,8 @@ Once inside CNCF Slack, use the search bar to find and join the KubeEdge channel
 Note: Direct Slack links may not work unless you are already logged in. Always join via [slack.cncf.io](https://slack.cncf.io/) first.
 
 ## Step 3: Follow Community Guidelines
-- Be respectful and inclusive.  
-- Ask questions in the most relevant channel.  
-- Search existing discussions before posting.  
-- For contributor discussions, prefer `#kubeedge-dev`.  
 
+- Be respectful and inclusive.
+- Ask questions in the most relevant channel.
+- Search existing discussions before posting.
+- For contributor discussions, prefer `#kubeedge-dev`.


### PR DESCRIPTION
…#6440 in kubeEdge repo

* **Please check if the PR fulfills these requirements**

- [X] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Which issue(s) this PR fixes**:
Fixes #6440 in the KubeEdge main repository.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Docs update


* **What is the current behavior?** (You can also link to an open issue here)
The [Slack community page](https://kubeedge.io/docs/community/slack/)
 references outdated / auth-restricted links, and lacks clear guidance on joining and navigating the CNCF Slack workspace.


* **What is the new behavior (if this is a feature change)?**
-Updated Slack invite links to use CNCF’s official Slack onboarding flow
-Added step-by-step instructions for new contributors
-Organized channels by category with descriptions
-Included best practices for community participation


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
This improves new contributor onboarding by reducing confusion around Slack links and channels, while aligning with CNCF Slack workspace structure.