### PR TITLE
docs: update Device CRDs documentation and fix broken link

### DIFF
--- a/docs/concept/device/device_crds.md
+++ b/docs/concept/device/device_crds.md
@@ -1,6 +1,7 @@
------
-
-## title: Device CRDs sidebar\_position: 3
+---
+title: Device CRDs
+sidebar_position: 3
+---
 
 KubeEdge supports device management using **Kubernetes Custom Resource Definitions (CRDs)** and a **Device Mapper** corresponding to the device being used.
 


### PR DESCRIPTION
- Fixed the broken link to the device-crd-v1beta1 proposal.
- Improved clarity and formatting of Device CRDs documentation.
- Added explanations for YAML fields and usage steps.
- Documentation-only update; no functional changes.