### PR TITLE
docs: clarify differences between binary installation and keadm installation

### DIFF
--- a/docs/setup/install-with-binary.md
+++ b/docs/setup/install-with-binary.md
@@ -2,7 +2,13 @@
 title: Installing KubeEdge with Binary
 sidebar_position: 4
 ---
-Deploying KubeEdge with binary is used to test, never use this way in production environment.
+Binary installation is mainly intended for testing and development, and is generally not recommended for production environments.
+
+## When to choose binary installation
+
+Binary installation is more suitable for advanced users who want full control over binary placement, configuration files, and service management. It is usually a better fit for custom environments, development, debugging, or cases where users do not want to rely on `keadm`.
+
+Compared with `keadm`, binary installation provides more flexibility, but it also requires more manual setup.
 
 ## Limitation
 

--- a/docs/setup/install-with-keadm.md
+++ b/docs/setup/install-with-keadm.md
@@ -3,7 +3,14 @@ title: Installing KubeEdge with Keadm
 sidebar_position: 3
 ---
 
-Keadm is used to install the cloud and edge components of KubeEdge. It does not handle the installation of Kubernetes and its [runtime environment](https://kubeedge.io/docs/setup/prerequisites/runtime).
+Keadm is used to install the cloud and edge components of KubeEdge. It does not handle the installation of Kubernetes and its 
+[runtime environment](https://kubeedge.io/docs/setup/prerequisites/runtime).
+
+## When to choose keadm
+
+`keadm` is recommended for most users who want a simpler and more automated installation experience. It helps set up KubeEdge components in a more standardized way and is usually a better choice for quick start, evaluation, and standard deployments.
+
+Compared with manual binary installation, `keadm` reduces the amount of manual work required for configuration and service setup.
 
 Please refer to [Kubernetes compatibility](https://github.com/kubeedge/kubeedge#kubernetes-compatibility) documentation to check **Kubernetes compatibility** and ascertain the Kubernetes version to be installed.
 

--- a/docs/welcome/getting-started.md
+++ b/docs/welcome/getting-started.md
@@ -10,6 +10,18 @@ In this quick-start guide, we will explain:
 - A few common ways of deploying KubeEdge.
 - Links for further reading.
 
+## Choose an installation method
+
+KubeEdge provides two common installation approaches: using `keadm` and installing from binaries manually. 
+
+- **`keadm`** is recommended for most users who want a simpler and more automated installation experience.
+- **Binary installation** is more suitable for users who need more flexibility and full control over binary placement, configuration files, and service setup.
+
+| Method | Best for | Automation | Configuration and service setup |
+| --- | --- | --- | --- |
+| `keadm` | quick start, evaluation, and standard deployments | higher | mostly handled by `keadm` |
+| binary installation | custom environments, development, and debugging | lower | managed manually |
+
 ## Dependencies
 
 For cloud side, we need:


### PR DESCRIPTION
## What this PR does

This PR improves the installation documentation by clarifying the differences between binary installation and keadm installation.

## Why this is needed

New users may be confused about which installation method to choose, since the two approaches differ in automation level, setup flow, and service/configuration management.

## Changes made

* added a short comparison in the getting started documentation
* clarified when to choose `keadm`
* clarified when to choose binary installation

## Related issue

Fixes #6688
