### PR TITLE
docs: clarify Kubernetes and runtime prerequisites before installing KubeEdge

### DIFF
--- a/docs/setup/install-with-keadm.md
+++ b/docs/setup/install-with-keadm.md
@@ -3,7 +3,11 @@ title: Installing KubeEdge with Keadm
 sidebar_position: 3
 ---
 
-Keadm is used to install the cloud and edge components of KubeEdge. It does not handle the installation of Kubernetes and its [runtime environment](https://kubeedge.io/docs/setup/prerequisites/runtime).
+Keadm is used to install the cloud and edge components of KubeEdge. It does not install Kubernetes or the [runtime environment](https://kubeedge.io/docs/setup/prerequisites/runtime). Before using `keadm`, make sure your Kubernetes cluster and runtime environment are already prepared.
+
+## Important note
+
+Installing KubeEdge with `keadm` does not install Kubernetes or the container runtime. `keadm` only installs KubeEdge components. Before running `keadm init` or `keadm join`, make sure Kubernetes and the runtime environment are already installed and working properly.
 
 Please refer to [Kubernetes compatibility](https://github.com/kubeedge/kubeedge#kubernetes-compatibility) documentation to check **Kubernetes compatibility** and ascertain the Kubernetes version to be installed.
 

--- a/docs/welcome/getting-started.md
+++ b/docs/welcome/getting-started.md
@@ -10,6 +10,10 @@ In this quick-start guide, we will explain:
 - A few common ways of deploying KubeEdge.
 - Links for further reading.
 
+## Before you begin
+
+KubeEdge is installed on top of an existing Kubernetes environment. Installing KubeEdge does not automatically provision Kubernetes or the container runtime, so make sure they are prepared before installation.
+
 ## Dependencies
 
 For cloud side, we need:


### PR DESCRIPTION
## What this PR does

This PR improves the installation documentation by clarifying that installing KubeEdge does not automatically install Kubernetes or the container runtime.

## Why this is needed

New users may misunderstand `keadm` as a tool that provisions a full Kubernetes environment together with KubeEdge. In practice, Kubernetes and the runtime environment must be prepared separately before installing KubeEdge.

## Changes made

* clarified the scope of `keadm` in the installation documentation
* added a reminder that Kubernetes and the runtime environment must be prepared before installation
* improved the getting started documentation to reduce this misunderstanding

## Issue

Fixes #6679
