### PR TITLE
fix broken Slack channel links on the community page

### DIFF
--- a/docs/community/slack.md
+++ b/docs/community/slack.md
@@ -11,13 +11,13 @@ If you have any questions you are always welcome in KubeEdge channels on the CNC
 - Navigate to https://slack.cncf.io/ and create your Slack account.
 - Find us in one of the following channels and ask your question:
     - [#kubeedge](https://cloud-native.slack.com/archives/C066UJZJKQE)
-    - [#kubeedge-announcement](https://cloud-native.slack.com/archives/C067DTAF4Q1)
-    - [#kubeedge-dev](https://cloud-native.slack.com/archives/C06718TB6F4)
+    - [#kubeedge-announcement](https://cloud-native.slack.com/archives/C06BCA5MR5Y)
+    - [#kubeedge-dev](https://cloud-native.slack.com/archives/C06C13NGR0Q)
     - [#kubeedge-dashboard](https://cloud-native.slack.com/archives/C066LNA3015)
-    - [#kubeedge-docs](https://cloud-native.slack.com/archives/C06718RDHCJ)
-    - [#kubeedge-sig-ai](https://cloud-native.slack.com/archives/C067DTGJJM7)
-    - [#kubeedge-sig-device-iot](https://cloud-native.slack.com/archives/C067Q8J3KTJ)
+    - [#kubeedge-docs](https://cloud-native.slack.com/archives/C06BCA5V1LJ)
+    - [#kubeedge-sig-ai](https://cloud-native.slack.com/archives/C06BQURDQQ1)
+    - [#kubeedge-sig-device-iot](https://cloud-native.slack.com/archives/C06BC6VQHFD)
     - [#kubeedge-sig-robotics](https://cloud-native.slack.com/archives/C066LNMUME3)
-    - [#kubeedge-sig-security](https://cloud-native.slack.com/archives/C067Q8LC3T2)
-    - [#kubeedge-sig-mec](https://cloud-native.slack.com/archives/C06716458P5)
+    - [#kubeedge-sig-security](https://cloud-native.slack.com/archives/C06C13NN1UG)
+    - [#kubeedge-sig-mec](https://cloud-native.slack.com/archives/C06B5LRV3B8)
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

**Which issue(s) this PR fixes**:

Fixes #816

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Docs Update


* **What is the current behavior?** (You can also link to an open issue here)


Several Slack channel links on the community Slack page (docs/community/slack.md) are broken. The channel IDs they point to are invalid, so following any of the affected links doesn't land users in the right channel. [](url)

* **What is the new behavior (if this is a feature change)?**

Updated the channel IDs for the seven affected channels to their correct values: 
kubeedge-announcement, kubeedge-dev, kubeedge-docs, kubeedge-sig-ai, kubeedge-sig-device-iot, kubeedge-sig-security, and kubeedge-sig-mec.


The links now resolve to the intended Slack channels.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

NO

* **Other information**:

The IDs for #kubeedge, #kubeedge-dashboard, and #kubeedge-sig-robotics were left unchanged as they were not reported as broken in the issue.

Testing Fixed links 
https://github.com/user-attachments/assets/7f8d1608-ab03-4942-8cac-1aa0d188ce95

