### PR TITLE
Fix: the wrapping text in case study

### DIFF
--- a/src/components/caseCard/styles.scss
+++ b/src/components/caseCard/styles.scss
@@ -76,3 +76,113 @@ html[data-theme="dark"] {
     border: 1px solid rgba(255, 255, 255, 0.06);
   }
 }
+
+@media (max-width: 768px) {
+  .case-card {
+    grid-template-areas:
+      "title"
+      "hr"
+      "sub"
+      "desc"
+      "date"
+      "btn";
+    grid-template-columns: 1fr;
+    grid-column-gap: 0;
+    padding: 20px;
+    min-height: auto;
+
+    .title {
+      font-size: 22px;
+      margin-bottom: 12px;
+    }
+
+    hr {
+      height: 3px !important;
+      width: 36px !important;
+      margin: 8px 0;
+    }
+
+    .sub {
+      font-size: 18px;
+      margin-top: 10px;
+    }
+
+    .desc {
+      font-size: 15px;
+      overflow: visible;
+      text-overflow: inherit;
+      display: block;
+      -webkit-line-clamp: unset;
+      -webkit-box-orient: unset;
+      margin-top: 12px;
+      white-space: normal;
+    }
+
+    .date {
+      font-size: 12px;
+      margin-top: 12px;
+      align-self: start;
+    }
+
+    a {
+      justify-self: start;
+      margin-top: 12px;
+      padding-left: 16px;
+      padding-right: 16px;
+    }
+  }
+}@media (max-width: 768px) {
+  .case-card {
+    grid-template-areas:
+      "title"
+      "hr"
+      "sub"
+      "desc"
+      "date"
+      "btn";
+    grid-template-columns: 1fr;
+    grid-column-gap: 0;
+    padding: 20px;
+    min-height: auto;
+
+    .title {
+      font-size: 22px;
+      margin-bottom: 12px;
+    }
+
+    hr {
+      height: 3px !important;
+      width: 36px !important;
+      margin: 8px 0;
+    }
+
+    .sub {
+      font-size: 18px;
+      margin-top: 10px;
+    }
+
+    .desc {
+      font-size: 15px;
+      overflow: visible;
+      text-overflow: inherit;
+      display: block;
+      -webkit-line-clamp: unset;
+      -webkit-box-orient: unset;
+      margin-top: 12px;
+      white-space: normal;
+    }
+
+    .date {
+      font-size: 12px;
+      margin-top: 12px;
+      align-self: start;
+    }
+
+    a {
+      justify-self: start;
+      margin-top: 12px;
+      padding-left: 16px;
+      padding-right: 16px;
+    }
+  }
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (not applicable)
* [ ] Docs have been added / updated (not applicable)

**Which issue(s) this PR fixes**:

Fixes #821

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

**What is the current behavior?** (You can also link to an open issue here)

The case study cards are not properly optimized for mobile screens. The content area becomes too narrow, causing excessive text wrapping and making the text difficult to read.

**What is the new behavior (if this is a feature change)?**

The card layout has been adjusted to improve responsiveness on smaller screens. The content now has better spacing and readability, reducing excessive text wrapping on mobile devices.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

**Other information**:

Tested using browser mobile emulation and verified on common mobile viewport sizes.
