### PR TITLE
fix: unnest Job Center header CTA

### DIFF
--- a/src/pages/job-center/index.js
+++ b/src/pages/job-center/index.js
@@ -18,7 +18,7 @@ export default function JobCenter() {
           <p className="job-center-subtitle">
             <Translate>
               Welcome to the KubeEdge Job Center. We wish you the best of luck
-              to find the right job or top telent here.
+              to find the right job or top talent here.
             </Translate>
           </p>
           <a

--- a/src/pages/job-center/index.js
+++ b/src/pages/job-center/index.js
@@ -6,39 +6,45 @@ import Translate from "@docusaurus/Translate";
 import "./index.scss";
 
 export default function JobCenter() {
-    const { jobcenterGlobalData } = usePluginData("jobcenter-global-dataPlugin");
+  const { jobcenterGlobalData } = usePluginData("jobcenter-global-dataPlugin");
 
-    return (
-        <Layout>
-            <div className="job-center-container">
-                <div className="job-center-header">
-                    <h1 className="job-center-title">
-                        <Translate>Job Center</Translate>
-                    </h1>
-                    <p className="job-center-subtitle">
-                        <Translate>Welcome to the KubeEdge Job Center. We wish you the best of luck to find the right job or top telent here.</Translate>
-                    </p>
-                    <button className="button" type="button">
-                        <a href="https://github.com/kubeedge/website/blob/master/src/components/jobCard/README.md" target="_blank">
-                            <Translate>POST A JOB</Translate>
-                        </a>
-                    </button>
-                </div>
-                <div className="job-list">
-                    {jobcenterGlobalData.map((item, index) => (
-                        <JobCard
-                            key={item.metadata?.permalink || item.metadata?.title || index}
-                            title={item.metadata?.title}
-                            company={item.metadata?.frontMatter?.company}
-                            date={item.metadata?.frontMatter?.date}
-                            expirydate={item.metadata?.frontMatter?.expirydate}
-                            address={item.metadata?.frontMatter?.address}
-                            logo={item.metadata?.frontMatter?.logo}
-                            link={item.metadata?.permalink}
-                        />
-                    ))}
-                </div>
-            </div>
-        </Layout>
-    );
+  return (
+    <Layout>
+      <div className="job-center-container">
+        <div className="job-center-header">
+          <h1 className="job-center-title">
+            <Translate>Job Center</Translate>
+          </h1>
+          <p className="job-center-subtitle">
+            <Translate>
+              Welcome to the KubeEdge Job Center. We wish you the best of luck
+              to find the right job or top telent here.
+            </Translate>
+          </p>
+          <a
+            className="button"
+            href="https://github.com/kubeedge/website/blob/master/src/components/jobCard/README.md"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <Translate>POST A JOB</Translate>
+          </a>
+        </div>
+        <div className="job-list">
+          {jobcenterGlobalData.map((item, index) => (
+            <JobCard
+              key={item.metadata?.permalink || item.metadata?.title || index}
+              title={item.metadata?.title}
+              company={item.metadata?.frontMatter?.company}
+              date={item.metadata?.frontMatter?.date}
+              expirydate={item.metadata?.frontMatter?.expirydate}
+              address={item.metadata?.frontMatter?.address}
+              logo={item.metadata?.frontMatter?.logo}
+              link={item.metadata?.permalink}
+            />
+          ))}
+        </div>
+      </div>
+    </Layout>
+  );
 }

--- a/src/pages/job-center/index.scss
+++ b/src/pages/job-center/index.scss
@@ -15,7 +15,7 @@
     .button {
       background-color: #f8f9fa;
       border: none;
-      color: white;
+      color: #3578e5;
       text-align: center;
       text-decoration: none;
       display: inline-block;


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Which issue(s) this PR fixes**:
Fixes #843

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

The `POST A JOB` CTA in the Job Center header renders as a nested interactive element: `<button><a ...></a></button>`.

* **What is the new behavior (if this is a feature change)?**

The header CTA is now a single external anchor with the existing button styling and `rel="noopener noreferrer"`.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

* **Other information**:

- Verified with `npx -y -p node@20 -c "node node_modules/@docusaurus/core/bin/docusaurus.mjs build --locale en"`
- Verified with `npx -y -p node@20 -p prettier@3.3.3 prettier --check src/pages/job-center/index.js src/pages/job-center/index.scss`

### After the fix: 

<img width="1800" height="362" alt="image" src="https://github.com/user-attachments/assets/a6199063-d069-4bf5-a50e-bfe149410c3d" />

<img width="1279" height="720" alt="image" src="https://github.com/user-attachments/assets/d1e323af-a8df-4c3d-ad2a-f90b549bbb7d" />
