### PR TITLE
fix: add alt text to About avatar

### DIFF
--- a/src/components/about/index.js
+++ b/src/components/about/index.js
@@ -6,17 +6,17 @@ import "./styles.scss";
 export default function About() {
   return (
     <SectionContainer className="aboutContainer">
-      <div className={"row"}>
-        <div className={"profile"}>
-          <img alt="KubeEdge" className={"portrait"} src="img/avatar.png"></img>
-          <div className={"portraitTitle"}>
-            <h3 className={"name"}>KubeEdge</h3>
-            <h3 className={"jobTitle"}>
+      <div className="row">
+        <div className="profile">
+          <img alt="KubeEdge" className="portrait" src="img/avatar.png" />
+          <div className="portraitTitle">
+            <h3 className="name">KubeEdge</h3>
+            <h3 className="jobTitle">
               <Translate>Kubernetes Native Edge Computing Framework</Translate>
             </h3>
           </div>
         </div>
-        <div className={"description"}>
+        <div className="description">
           <p>
             <Translate>
               KubeEdge is an open source system for extending native

--- a/src/components/about/index.js
+++ b/src/components/about/index.js
@@ -8,13 +8,11 @@ export default function About() {
     <SectionContainer className="aboutContainer">
       <div className={"row"}>
         <div className={"profile"}>
-          <img className={"portrait"} src="img/avatar.png"></img>
+          <img alt="KubeEdge" className={"portrait"} src="img/avatar.png"></img>
           <div className={"portraitTitle"}>
             <h3 className={"name"}>KubeEdge</h3>
             <h3 className={"jobTitle"}>
-              <Translate>
-                Kubernetes Native Edge Computing Framework
-              </Translate>
+              <Translate>Kubernetes Native Edge Computing Framework</Translate>
             </h3>
           </div>
         </div>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Which issue(s) this PR fixes**:
Fixes #846

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

The About section avatar image renders without an `alt` attribute.

* **What is the new behavior (if this is a feature change)?**

The avatar image now includes `alt="KubeEdge"`.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

* **Other information**:

- Verified on a local Node 20 Docusaurus dev server at `/`
- Verified DOM after the fix: the About avatar image now exposes `alt="KubeEdge"`
- Verified with `npx -y -p node@20 -p prettier@3.3.3 prettier --check src/components/about/index.js`

### After the fix:

<img width="1800" height="294" alt="image" src="https://github.com/user-attachments/assets/b1391459-93b8-4fa0-aa99-865608d5c02c" />
