### PR TITLE
fix(blog): replace stale setup links

### DIFF
--- a/blog/release-v1.5/index.mdx
+++ b/blog/release-v1.5/index.mdx
@@ -53,7 +53,7 @@ Release details - [Release v1.5](https://github.com/kubeedge/kubeedge/releases/t
 
 :::note
 
-How to set up KubeEdge - [KubeEdge Setup](https://kubeedge.io/en/docs/setup/keadm/)
+How to set up KubeEdge - [KubeEdge Setup](https://kubeedge.io/docs/setup/install-with-keadm)
 
 :::
 

--- a/blog/release-v1.6/index.mdx
+++ b/blog/release-v1.6/index.mdx
@@ -53,7 +53,7 @@ Release details - [Release v1.6](https://github.com/kubeedge/kubeedge/releases/t
 
 :::note
 
-How to set up KubeEdge - [KubeEdge Setup](https://kubeedge.io/en/docs/setup/keadm/)
+How to set up KubeEdge - [KubeEdge Setup](https://kubeedge.io/docs/setup/install-with-keadm)
 
 :::
 

--- a/blog/release-v1.7/index.mdx
+++ b/blog/release-v1.7/index.mdx
@@ -53,7 +53,7 @@ Release details - [Release v1.7](https://github.com/kubeedge/kubeedge/releases/t
 
 :::note
 
-How to set up KubeEdge - [Setup](https://kubeedge.io/en/docs/setup/keadm/)
+How to set up KubeEdge - [Setup](https://kubeedge.io/docs/setup/install-with-keadm)
 
 :::
 

--- a/blog/release-v1.8/index.mdx
+++ b/blog/release-v1.8/index.mdx
@@ -51,7 +51,7 @@ Release details - [Release v1.8](https://github.com/kubeedge/kubeedge/releases/t
 
 :::note
 
-How to set up KubeEdge - [Setup](https://kubeedge.io/en/docs/setup/keadm/)
+How to set up KubeEdge - [Setup](https://kubeedge.io/docs/setup/install-with-keadm)
 
 :::
 

--- a/blog/release-v1.9/index.mdx
+++ b/blog/release-v1.9/index.mdx
@@ -60,7 +60,7 @@ Release details - [Release v1.9](https://github.com/kubeedge/kubeedge/releases/t
 
 :::note
 
-How to set up KubeEdge - [Setup](https://kubeedge.io/en/docs/setup/keadm/)
+How to set up KubeEdge - [Setup](https://kubeedge.io/docs/setup/install-with-keadm)
 
 :::
 

--- a/i18n/zh/docusaurus-plugin-content-blog/release-v1.5/index.mdx
+++ b/i18n/zh/docusaurus-plugin-content-blog/release-v1.5/index.mdx
@@ -51,7 +51,7 @@ Release details - [Release v1.5](https://github.com/kubeedge/kubeedge/releases/t
 
 :::note
 
-How to set up KubeEdge - [KubeEdge Setup](https://kubeedge.io/en/docs/setup/keadm/)
+How to set up KubeEdge - [KubeEdge Setup](https://kubeedge.io/zh/docs/setup/install-with-keadm)
 
 :::
 

--- a/i18n/zh/docusaurus-plugin-content-blog/release-v1.6/index.mdx
+++ b/i18n/zh/docusaurus-plugin-content-blog/release-v1.6/index.mdx
@@ -51,7 +51,7 @@ Release details - [Release v1.6](https://github.com/kubeedge/kubeedge/releases/t
 
 :::note
 
-How to set up KubeEdge - [KubeEdge Setup](https://kubeedge.io/en/docs/setup/keadm/)
+How to set up KubeEdge - [KubeEdge Setup](https://kubeedge.io/zh/docs/setup/install-with-keadm)
 
 :::
 

--- a/i18n/zh/docusaurus-plugin-content-blog/release-v1.7/index.mdx
+++ b/i18n/zh/docusaurus-plugin-content-blog/release-v1.7/index.mdx
@@ -51,7 +51,7 @@ Release details - [Release v1.7](https://github.com/kubeedge/kubeedge/releases/t
 
 :::note
 
-How to set up KubeEdge - [Setup](https://kubeedge.io/en/docs/setup/keadm/)
+How to set up KubeEdge - [Setup](https://kubeedge.io/zh/docs/setup/install-with-keadm)
 
 :::
 

--- a/i18n/zh/docusaurus-plugin-content-blog/release-v1.8/index.mdx
+++ b/i18n/zh/docusaurus-plugin-content-blog/release-v1.8/index.mdx
@@ -49,7 +49,7 @@ Release details - [Release v1.8](https://github.com/kubeedge/kubeedge/releases/t
 
 :::note
 
-How to set up KubeEdge - [Setup](https://kubeedge.io/en/docs/setup/keadm/)
+How to set up KubeEdge - [Setup](https://kubeedge.io/zh/docs/setup/install-with-keadm)
 
 :::
 

--- a/i18n/zh/docusaurus-plugin-content-blog/release-v1.9/index.mdx
+++ b/i18n/zh/docusaurus-plugin-content-blog/release-v1.9/index.mdx
@@ -58,7 +58,7 @@ Release details - [Release v1.9](https://github.com/kubeedge/kubeedge/releases/t
 
 :::note
 
-How to set up KubeEdge - [Setup](https://kubeedge.io/en/docs/setup/keadm/)
+How to set up KubeEdge - [Setup](https://kubeedge.io/zh/docs/setup/install-with-keadm)
 
 :::
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (not applicable for this documentation-only fix)
- [x] Docs have been added / updated (for bug fixes / features)

**Which issue(s) this PR fixes**:

N/A

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

The v1.5 through v1.9 release posts link to `https://kubeedge.io/en/docs/setup/keadm/`, which returns a 404 page.

* **What is the new behavior (if this is a feature change)?**

English release posts now link to the current English keadm installation guide. Chinese release posts now link to the corresponding Chinese guide.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

* **Other information**:

Validated with `npx --yes yarn@1.22.22 build` and checked generated English and Chinese release post pages for the updated links.