### PR TITLE
fix: mark footer logos decorative

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -205,10 +205,10 @@ const config = {
             html: '<p style="font-size: large;">KubeEdge is a <a href="https://cncf.io/">Cloud Native Computing Foundation</a> graduated project.</p>',
           },
           {
-            html: '<img src="https://github.com/cncf/artwork/blob/main/other/cncf/horizontal/color/cncf-color.png?raw=true" class="footer__logo light">',
+            html: '<img src="https://github.com/cncf/artwork/blob/main/other/cncf/horizontal/color/cncf-color.png?raw=true" alt="" class="footer__logo light">',
           },
           {
-            html: '<img src="https://github.com/cncf/artwork/blob/main/other/cncf/horizontal/white/cncf-white.png?raw=true" class="footer__logo dark">',
+            html: '<img src="https://github.com/cncf/artwork/blob/main/other/cncf/horizontal/white/cncf-white.png?raw=true" alt="" class="footer__logo dark">',
           },
           {
             html: '<p>Copyright KubeEdge a Series of LF Projects, LLC. For website terms of use, trademark policy and other project policies please see <a href="https://lfprojects.org/policies/" target="_blank" rel="noopener noreferrer">lfprojects.org/policies</a>.</p>',


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (not applicable for this configuration-only fix)
- [ ] Docs have been added / updated (not applicable for this configuration-only fix)

**Which issue(s) this PR fixes**:

N/A

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

The footer's light and dark CNCF logo images are rendered without an `alt` attribute on every page.

* **What is the new behavior (if this is a feature change)?**

Both footer logos are explicitly marked decorative with `alt=""`. The adjacent text already identifies the Cloud Native Computing Foundation, so screen readers do not receive duplicate information.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

* **Other information**:

Validated with `npx --yes yarn@1.22.22 build` and checked generated English and Chinese homepage footer markup.

<img width="1800" height="333" alt="image" src="https://github.com/user-attachments/assets/a5ba7f88-e4f1-4e2a-803f-8b591ecc9c74" />