### PR TITLE
fix(docs): name Ianvs architecture diagram

### DIFF
--- a/docs/concept/ai/ianvs.md
+++ b/docs/concept/ai/ianvs.md
@@ -31,7 +31,9 @@ The architectures and related concepts are shown in the below figure. The ianvs 
 - Story Manager: the output management and presentation of the test case, e.g., leaderboards
 
 
-![Ianvs architecture diagram](/img/subproject/ianvs_arch.png)
+![Ianvs architecture diagram. Detailed description follows.](/img/subproject/ianvs_arch.png)
+
+The diagram presents a single-node workflow. User input enters the Test Environment Manager, which provides datasets and metrics to the Test Case Controller. The controller contains algorithm paradigms, a Generation Assistant, and a Simulation Controller, and sends output to the Story Manager. The Story Manager produces leaderboards and test reports. All three components are connected to local storage.
 
 More details on Ianvs components:
 1. Test-Environment Manager supports the CRUD of Test environments, which basically includes

--- a/docs/concept/ai/ianvs.md
+++ b/docs/concept/ai/ianvs.md
@@ -31,7 +31,7 @@ The architectures and related concepts are shown in the below figure. The ianvs 
 - Story Manager: the output management and presentation of the test case, e.g., leaderboards
 
 
-![](/img/subproject/ianvs_arch.png)
+![Ianvs architecture diagram](/img/subproject/ianvs_arch.png)
 
 More details on Ianvs components:
 1. Test-Environment Manager supports the CRUD of Test environments, which basically includes

--- a/i18n/zh/docusaurus-plugin-content-docs/current/concept/ai/ianvs.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/concept/ai/ianvs.md
@@ -31,7 +31,7 @@ Ianvs 的职责范围包括：
 - Story Manager：测试用例的输出管理和展示，例如排行榜
 
 
-![](/img/subproject/ianvs_arch.png)
+![Ianvs 架构图](/img/subproject/ianvs_arch.png)
 
 Ianvs 组件的更多细节：
 1. 测试环境管理器支持测试环境的 CRUD，包括

--- a/i18n/zh/docusaurus-plugin-content-docs/current/concept/ai/ianvs.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/concept/ai/ianvs.md
@@ -31,7 +31,9 @@ Ianvs 的职责范围包括：
 - Story Manager：测试用例的输出管理和展示，例如排行榜
 
 
-![Ianvs 架构图](/img/subproject/ianvs_arch.png)
+![Ianvs 架构图。下文提供详细说明。](/img/subproject/ianvs_arch.png)
+
+该图展示单节点工作流。用户输入进入 Test Environment Manager，该组件将数据集和指标提供给 Test Case Controller。控制器包含算法范式、Generation Assistant 和 Simulation Controller，并将输出发送至 Story Manager。Story Manager 生成排行榜和测试报告。三个组件均连接到本地存储。
 
 Ianvs 组件的更多细节：
 1. 测试环境管理器支持测试环境的 CRUD，包括


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (not applicable for this documentation-only fix)
- [x] Docs have been added / updated (for bug fixes / features)

**Which issue(s) this PR fixes**:

N/A

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

The Ianvs architecture figure uses empty Markdown image text in English and Chinese documentation. Generated pages therefore render the informative diagram without alternative text.

* **What is the new behavior (if this is a feature change)?**

The figure now has localized short alternative text that identifies an adjacent localized description in both documentation locales. The description conveys the single-node component flow and local-storage relationships shown in the diagram.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

* **Other information**:

Validated with `npx --yes yarn@1.22.22 build` and checked the generated and deployed English and Chinese Ianvs pages for the rendered image alternative text and adjacent descriptions.

<img width="1800" height="536" alt="image" src="https://github.com/user-attachments/assets/968ec9d4-bf1d-46e5-82ed-e4989db70c42" />
